### PR TITLE
Add FastAPI service for managing backup apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ Orquestador liviano que:
 
 ---
 
+## API Rápida
+
+El proyecto incluye un servicio FastAPI para registrar aplicaciones a respaldar.
+
+### Ejecutar
+
+```bash
+uvicorn app.main:app --reload
+```
+
+La documentación OpenAPI está disponible en `http://localhost:8000/docs`.
+
 ## 1) Requisitos
 - Docker y Docker Compose.
 - Una cuenta de Google Drive (del orquestador; **no hay usuarios finales en Drive**).

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./apps.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,45 @@
+from fastapi import Depends, FastAPI, HTTPException
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/apps", response_model=schemas.AppCreate)
+def create_app(app_in: schemas.AppCreate, db: Session = Depends(get_db)):
+    existing = db.query(models.App).filter(models.App.name == app_in.name).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="App already exists")
+    db_app = models.App(name=app_in.name)
+    db.add(db_app)
+    db.commit()
+    db.refresh(db_app)
+    return db_app
+
+
+@app.get("/apps", response_model=list[schemas.AppCreate])
+def list_apps(db: Session = Depends(get_db)):
+    apps = db.query(models.App).all()
+    return apps
+
+
+@app.delete("/apps/{app_id}")
+def delete_app(app_id: int, db: Session = Depends(get_db)):
+    app_db = db.query(models.App).get(app_id)
+    if not app_db:
+        raise HTTPException(status_code=404, detail="App not found")
+    db.delete(app_db)
+    db.commit()
+    return {"detail": "App deleted"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+
+from .database import Base
+
+
+class App(Base):
+    __tablename__ = "apps"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class AppCreate(BaseModel):
+    name: str
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+sqlalchemy


### PR DESCRIPTION
## Summary
- initialize FastAPI project with SQLite persistence
- add /apps endpoints to register, list and remove apps
- document API quick start

## Testing
- `python -m uvicorn app.main:app --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4beedda388332bf08053efeb28339