### PR TITLE
Add web UI templates using Bootstrap and AJAX

### DIFF
--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -1,0 +1,33 @@
+from flask import Flask, render_template, request, jsonify
+
+
+def create_app() -> Flask:
+    """Application factory for the backup orchestrator UI."""
+    app = Flask(__name__)
+    registered_apps: list[dict] = []
+
+    @app.route("/")
+    def index() -> str:
+        """Render main panel."""
+        return render_template("index.html")
+
+    @app.get("/apps")
+    def list_apps() -> list[dict]:
+        """Return registered apps as JSON."""
+        return jsonify(registered_apps)
+
+    @app.post("/apps")
+    def register_app() -> tuple[dict, int]:
+        """Register a new app from JSON payload."""
+        data = request.get_json(force=True)
+        if not data:
+            return {"error": "invalid payload"}, 400
+        registered_apps.append(data)
+        return {"status": "ok"}, 201
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(host="0.0.0.0", port=5550, debug=True)

--- a/orchestrator/app/static/js/app.js
+++ b/orchestrator/app/static/js/app.js
@@ -1,0 +1,35 @@
+async function loadApps() {
+  const resp = await fetch('/apps');
+  const apps = await resp.json();
+  const tbody = document.querySelector('#apps-table tbody');
+  tbody.innerHTML = '';
+  apps.forEach(app => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${app.name}</td><td>${app.url}</td><td>${app.token}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadApps();
+
+  document.getElementById('app-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const payload = {
+      name: document.getElementById('name').value,
+      url: document.getElementById('url').value,
+      token: document.getElementById('token').value
+    };
+    const resp = await fetch('/apps', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (resp.ok) {
+      e.target.reset();
+      const modal = bootstrap.Modal.getInstance(document.getElementById('appModal'));
+      modal.hide();
+      loadApps();
+    }
+  });
+});

--- a/orchestrator/app/templates/app_form.html
+++ b/orchestrator/app/templates/app_form.html
@@ -1,0 +1,27 @@
+<div class="modal fade" id="appModal" tabindex="-1" aria-labelledby="appModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="appModalLabel">Register App</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="app-form">
+          <div class="mb-3">
+            <label for="name" class="form-label">Name</label>
+            <input type="text" class="form-control" id="name" required>
+          </div>
+          <div class="mb-3">
+            <label for="url" class="form-label">URL</label>
+            <input type="url" class="form-control" id="url" required>
+          </div>
+          <div class="mb-3">
+            <label for="token" class="form-label">Token</label>
+            <input type="text" class="form-control" id="token" required>
+          </div>
+          <button type="submit" class="btn btn-primary">Save</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/orchestrator/app/templates/base.html
+++ b/orchestrator/app/templates/base.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Backup Orchestrator</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+  </body>
+</html>

--- a/orchestrator/app/templates/index.html
+++ b/orchestrator/app/templates/index.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container py-4">
+  <h1 class="mb-4">Registered Apps</h1>
+  <table class="table" id="apps-table">
+    <thead>
+      <tr><th>Name</th><th>URL</th><th>Token</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#appModal">Add App</button>
+</div>
+{% include 'app_form.html' %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add Flask app with Jinja2 templates for main panel and app registration form
- Style pages with Bootstrap and include modal-based form
- Implement frontend fetch calls to list and register apps without page reload

## Testing
- `python -m py_compile orchestrator/app/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4beef3408833282a8e5edfc6bc8ad