### PR TITLE
chore: update compose network usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,26 +6,6 @@ services:
     container_name: backuper
     volumes:
       - backups:/backups
-    ports:
-      - "8000:8000"
-    networks:
-      - backups_net
-
-  app1:
-    image: alpine
-    container_name: app1
-    command: sh -c "echo 'app1 data' > /data.txt && tail -f /dev/null"
-    volumes:
-      - backups:/backups
-    networks:
-      - backups_net
-
-  app2:
-    image: alpine
-    container_name: app2
-    command: sh -c "echo 'app2 data' > /data.txt && tail -f /dev/null"
-    volumes:
-      - backups:/backups
     networks:
       - backups_net
 
@@ -35,3 +15,4 @@ volumes:
 networks:
   backups_net:
     driver: bridge
+    name: backups_net


### PR DESCRIPTION
## Summary
- drop example app containers and host port mapping
- define internal network `backups_net` for external app containers

## Testing
- `pytest`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c2f98c8c8332ba85de62e8480591