### PR TITLE
feat: load database URL from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=sqlite:///./apps.db
+PORT=8000
+

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ backup-orchestrator/
 ```
 
 ## 3) Variables (.env)
-Crear un archivo `.env` en la raíz:
+Copiá el archivo `.env.example` a `.env` en la raíz del proyecto y ajustá las variables según sea necesario:
+
+```bash
+cp .env.example .env
+```
+
+Luego editá el archivo con tus propios valores:
 
 ```
 # UI y seguridad

--- a/app/database.py
+++ b/app/database.py
@@ -1,7 +1,9 @@
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-DATABASE_URL = "sqlite:///./apps.db"
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./apps.db")
 
 engine = create_engine(
     DATABASE_URL, connect_args={"check_same_thread": False}


### PR DESCRIPTION
## Summary
- configure database engine using `DATABASE_URL` env var
- add `.env.example` with sample config
- document copying `.env.example` to `.env`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4dad10be48332bbdeb7a14632ee71