### PR TITLE
Add __main__ entrypoint for orchestrator package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ COPY orchestrator ./orchestrator
 
 EXPOSE 5550
 
+# Run the orchestrator using the package's __main__ entry point
 CMD ["python", "-m", "orchestrator.app"]

--- a/orchestrator/app/__main__.py
+++ b/orchestrator/app/__main__.py
@@ -1,0 +1,7 @@
+import os
+from . import create_app
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "5550")), debug=True)
+


### PR DESCRIPTION
## Summary
- add `orchestrator.app.__main__` to launch the Flask app via `python -m orchestrator.app`
- document Docker command to use package entry point

## Testing
- `python -m py_compile orchestrator/app/__main__.py`
- `python -m orchestrator.app & sleep 3; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68c4eb969f808332af96318cb8ceaeff