### PR TITLE
Add scheduler and backup client

### DIFF
--- a/orchestrator/app/models.py
+++ b/orchestrator/app/models.py
@@ -10,3 +10,5 @@ class App(Base):
     name = Column(String, unique=True, nullable=False)
     url = Column(String, nullable=False)
     token = Column(String, nullable=False)
+    # Cron-style schedule for backup tasks
+    schedule = Column(String, nullable=True)

--- a/orchestrator/scheduler/__init__.py
+++ b/orchestrator/scheduler/__init__.py
@@ -1,0 +1,44 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from orchestrator.app.database import SessionLocal
+from orchestrator.app.models import App
+from orchestrator.services.client import BackupClient
+
+scheduler = BackgroundScheduler()
+
+
+def schedule_app_backups() -> None:
+    """Load apps from the database and register their backup jobs."""
+    with SessionLocal() as db:
+        apps = db.query(App).all()
+        for app in apps:
+            if not app.schedule:
+                continue
+            job_id = f"backup_{app.id}"
+            trigger = CronTrigger.from_crontab(app.schedule)
+            scheduler.add_job(
+                run_backup,
+                trigger,
+                args=[app.id],
+                id=job_id,
+                replace_existing=True,
+            )
+
+
+def run_backup(app_id: int) -> None:
+    """Execute backup for the given app id."""
+    with SessionLocal() as db:
+        app = db.query(App).get(app_id)
+        if not app:
+            return
+    client = BackupClient(app.url, app.token)
+    if client.check_capabilities():
+        client.export_backup(app.name)
+
+
+def start() -> None:
+    """Start the background scheduler if not already running."""
+    if not scheduler.running:
+        schedule_app_backups()
+        scheduler.start()

--- a/orchestrator/services/__init__.py
+++ b/orchestrator/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service clients used by the orchestrator."""

--- a/orchestrator/services/client.py
+++ b/orchestrator/services/client.py
@@ -1,0 +1,54 @@
+import io
+import os
+from typing import Iterable
+
+import requests
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaIoBaseUpload
+
+
+class BackupClient:
+    """Client for interacting with app backup endpoints and uploading to Drive."""
+
+    def __init__(self, base_url: str, token: str):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def check_capabilities(self) -> bool:
+        """Verify that the app is ready for backup."""
+        resp = requests.get(
+            f"{self.base_url}/backup/capabilities", headers=self._headers(), timeout=30
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("ready", False)
+
+    def export_backup(self, app_name: str) -> None:
+        """Request backup export and upload the result to Google Drive."""
+        resp = requests.post(
+            f"{self.base_url}/backup/export",
+            headers=self._headers(),
+            stream=True,
+            timeout=300,
+        )
+        resp.raise_for_status()
+        self._upload_stream_to_drive(resp.iter_content(64 * 1024), f"{app_name}.bak")
+
+    def _upload_stream_to_drive(self, chunks: Iterable[bytes], filename: str) -> None:
+        """Upload an iterable of bytes to Google Drive using service account credentials."""
+        creds = service_account.Credentials.from_service_account_file(
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
+            scopes=["https://www.googleapis.com/auth/drive.file"],
+        )
+        drive = build("drive", "v3", credentials=creds)
+        buffer = io.BytesIO()
+        for chunk in chunks:
+            buffer.write(chunk)
+        buffer.seek(0)
+        media = MediaIoBaseUpload(buffer, mimetype="application/octet-stream")
+        file_metadata = {"name": filename}
+        drive.files().create(body=file_metadata, media_body=media, fields="id").execute()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 flask
 sqlalchemy
 python-dotenv
+APScheduler
+requests
+google-api-python-client
+google-auth


### PR DESCRIPTION
## Summary
- add cron schedule to apps and expose through API
- integrate APScheduler to trigger backups
- implement HTTP client to validate capability and export backups to Drive

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c4ebad78e08332bd408791f452063e