### PR TITLE
docs: cross-reference registration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,11 @@ docker exec -it backup-orchestrator rclone lsd gdrive:
 ```
 
 ## 6) Contrato v1 para las Apps
-Cada app que quiera respaldo:
-- Se **conecta a `backups_net`** en su propio compose (o `docker network connect`).
-- Expone un endpoint **solo interno** (escuchando en su contenedor) con **token**.
-
-Endpoints mínimos:
-- `GET /backup/capabilities` → JSON: `{ "version":"v1", "types":["db"], "est_seconds":123, "est_size": 104857600 }`
-- `POST /backup/export` → **stream** del backup (p.ej. `pg_dump -Fc`), con headers:
-  - `X-Checksum-SHA256: ...`
-  - `X-Size: <bytes>`
-  - `X-Format: pg_dump_Fc`
-  - Auth por header `Authorization: Bearer <TOKEN>`
-
-> Si el backup tarda mucho, la app puede devolver `202` con `job_id` y un `status_url`/`download` para que el orquestador lo consulte y descargue luego.
+Cada app que quiera respaldo debe conectarse a `backups_net` y exponer los
+endpoints internos `GET /backup/capabilities` y `POST /backup/export`,
+protegidos con token. La especificación completa, incluidos headers
+obligatorios y comportamiento asíncrono opcional, está en el
+[apartado de endpoints del registro de apps](docs/registro_de_apps.md#endpoints-que-debe-exponer-cada-app).
 
 ## 7) Registrar una App en la UI
 En **Apps → Agregar**:
@@ -107,8 +99,8 @@ En **Apps → Agregar**:
 Luego, **Probar ahora**. Deberías ver un archivo `NOMBRE_YYYYmmdd_HHMM.dump` en la carpeta de Drive.
 
 Para un detalle del flujo de registro vía API, ejemplos de peticiones HTTP y
-buenas prácticas de preparación de contenedores, ver
-[docs/registro_de_apps.md](docs/registro_de_apps.md).
+buenas prácticas de preparación de contenedores, ver el
+[Flujo de registro](docs/registro_de_apps.md#flujo-de-registro).
 
 ## 8) Política de retención
 Configurable por app. Ejemplo:

--- a/docs/registro_de_apps.md
+++ b/docs/registro_de_apps.md
@@ -1,13 +1,16 @@
 # Registro de aplicaciones y ejecución de respaldos
 
-Esta guía resume cómo integrar una aplicación con el orquestador de respaldos.
-Incluye el flujo de registro, parámetros requeridos, endpoints y buenas
-prácticas para preparar el contenedor de cada app.
+Esta guía complementa las instrucciones generales del
+[README](../README.md) y resume cómo integrar una aplicación con el
+orquestador de respaldos. Incluye el flujo de registro, parámetros
+requeridos, endpoints y buenas prácticas para preparar el contenedor de
+cada app.
 
 ## Flujo de registro
 
 1. **Preparar el contenedor de la app**
-   - Conéctalo a la red `backups_net`.
+   - Conéctalo a la red `backups_net` (ver
+     [instrucciones](../README.md#11-conectar-una-app-existente-a-backups_net)).
    - Exponé los endpoints internos `GET /backup/capabilities` y
      `POST /backup/export`, protegidos con un token.
    - Montá como _read-only_ las rutas de datos necesarias para generar el
@@ -40,6 +43,8 @@ prácticas para preparar el contenedor de cada app.
      ```json
      { "id": "mi-app", "status": "registered" }
      ```
+   - También se puede registrar desde la interfaz web como se describe en el
+     [README](../README.md#7-registrar-una-app-en-la-ui).
 
 3. **Ejecutar un respaldo manual**
    - Endpoint: `POST /api/apps/mi-app/backups`


### PR DESCRIPTION
## Summary
- trim README registration contract and link to detailed API guide
- add cross-links between README and registro_de_apps instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4ebbd30908332942c4fbbe8ca2c91