### PR TITLE
Add scheduling and retention fields

### DIFF
--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -30,6 +30,11 @@ def create_app() -> Flask:
                     "url": a.url,
                     "token": a.token,
                     "schedule": a.schedule,
+                    "drive_folder_id": a.drive_folder_id,
+                    "retention": {
+                        "daily": a.retention_daily,
+                        "weekly": a.retention_weekly,
+                    },
                 }
                 for a in apps
             ])
@@ -45,6 +50,9 @@ def create_app() -> Flask:
             url=data.get("url"),
             token=data.get("token"),
             schedule=data.get("schedule"),
+            drive_folder_id=data.get("drive_folder_id"),
+            retention_daily=(data.get("retention") or {}).get("daily"),
+            retention_weekly=(data.get("retention") or {}).get("weekly"),
         )
         with SessionLocal() as db:
             db.add(new_app)

--- a/orchestrator/app/models.py
+++ b/orchestrator/app/models.py
@@ -12,3 +12,8 @@ class App(Base):
     token = Column(String, nullable=False)
     # Cron-style schedule for backup tasks
     schedule = Column(String, nullable=True)
+    # Google Drive folder where backups will be stored
+    drive_folder_id = Column(String, nullable=True)
+    # Retention policy in days/weeks
+    retention_daily = Column(Integer, nullable=True)
+    retention_weekly = Column(Integer, nullable=True)

--- a/orchestrator/app/static/js/app.js
+++ b/orchestrator/app/static/js/app.js
@@ -18,7 +18,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const payload = {
       name: document.getElementById('name').value,
       url: document.getElementById('url').value,
-      token: document.getElementById('token').value
+      token: document.getElementById('token').value,
+      schedule: document.getElementById('schedule').value,
+      drive_folder_id: document.getElementById('drive_folder_id').value,
+      retention: {
+        daily: parseInt(document.getElementById('retention-daily').value) || null,
+        weekly: parseInt(document.getElementById('retention-weekly').value) || null
+      }
     };
     const resp = await fetch('/apps', {
       method: 'POST',

--- a/orchestrator/app/templates/app_form.html
+++ b/orchestrator/app/templates/app_form.html
@@ -19,6 +19,25 @@
             <label for="token" class="form-label">Token</label>
             <input type="text" class="form-control" id="token" required>
           </div>
+          <div class="mb-3">
+            <label for="schedule" class="form-label">Schedule</label>
+            <input type="text" class="form-control" id="schedule" placeholder="0 3 * * *">
+          </div>
+          <div class="mb-3">
+            <label for="drive_folder_id" class="form-label">Drive Folder ID</label>
+            <input type="text" class="form-control" id="drive_folder_id">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Retention</label>
+            <div class="input-group mb-2">
+              <span class="input-group-text" id="retention-daily-label">Daily</span>
+              <input type="number" class="form-control" id="retention-daily" aria-describedby="retention-daily-label">
+            </div>
+            <div class="input-group">
+              <span class="input-group-text" id="retention-weekly-label">Weekly</span>
+              <input type="number" class="form-control" id="retention-weekly" aria-describedby="retention-weekly-label">
+            </div>
+          </div>
           <button type="submit" class="btn btn-primary">Save</button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- add schedule, drive folder and retention inputs to app registration form
- send new form fields to backend
- persist scheduling, drive folder and retention data for apps

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4ee27c1e083328b0e4164b0b20963