### PR TITLE
Stream backups in chunks via rclone

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+"""Backuper orchestrator package."""

--- a/orchestrator/services/client.py
+++ b/orchestrator/services/client.py
@@ -1,19 +1,17 @@
-import io
 import os
+import subprocess
 from typing import Iterable
 
 import requests
-from google.oauth2 import service_account
-from googleapiclient.discovery import build
-from googleapiclient.http import MediaIoBaseUpload
 
 
 class BackupClient:
     """Client for interacting with app backup endpoints and uploading to Drive."""
 
-    def __init__(self, base_url: str, token: str):
+    def __init__(self, base_url: str, token: str, upload_buffer: int = 8 * 1024 * 1024):
         self.base_url = base_url.rstrip("/")
         self.token = token
+        self.upload_buffer = upload_buffer
 
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.token}"}
@@ -39,16 +37,18 @@ class BackupClient:
         self._upload_stream_to_drive(resp.iter_content(64 * 1024), f"{app_name}.bak")
 
     def _upload_stream_to_drive(self, chunks: Iterable[bytes], filename: str) -> None:
-        """Upload an iterable of bytes to Google Drive using service account credentials."""
-        creds = service_account.Credentials.from_service_account_file(
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
-            scopes=["https://www.googleapis.com/auth/drive.file"],
-        )
-        drive = build("drive", "v3", credentials=creds)
-        buffer = io.BytesIO()
-        for chunk in chunks:
-            buffer.write(chunk)
-        buffer.seek(0)
-        media = MediaIoBaseUpload(buffer, mimetype="application/octet-stream")
-        file_metadata = {"name": filename}
-        drive.files().create(body=file_metadata, media_body=media, fields="id").execute()
+        """Upload an iterable of bytes to Google Drive using rclone rcat."""
+        remote = os.environ.get("RCLONE_REMOTE", "drive:")
+        cmd = ["rclone", "rcat", f"{remote}{filename}"]
+        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+        if proc.stdin is None:
+            raise RuntimeError("Failed to open rclone stdin")
+        try:
+            for chunk in chunks:
+                for i in range(0, len(chunk), self.upload_buffer):
+                    proc.stdin.write(chunk[i : i + self.upload_buffer])
+        finally:
+            proc.stdin.close()
+            returncode = proc.wait()
+        if returncode != 0:
+            raise RuntimeError(f"rclone exited with status {returncode}")

--- a/tests/test_client_upload.py
+++ b/tests/test_client_upload.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import sys
+import tracemalloc
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from orchestrator.services.client import BackupClient
+
+
+def test_upload_stream_large_file_memory(monkeypatch):
+    client = BackupClient("http://example", "token")
+
+    written_sizes = []
+
+    class DummyStdin:
+        def write(self, data):
+            written_sizes.append(len(data))
+        def close(self):
+            pass
+
+    class DummyProcess:
+        def __init__(self):
+            self.stdin = DummyStdin()
+        def wait(self):
+            return 0
+
+    def fake_popen(cmd, stdin, **kwargs):
+        assert cmd[:2] == ["rclone", "rcat"]
+        assert stdin == subprocess.PIPE
+        return DummyProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    def big_generator():
+        for _ in range(50):  # 50 MB total
+            yield b"x" * (1024 * 1024)
+
+    tracemalloc.start()
+    client._upload_stream_to_drive(big_generator(), "big.bak")
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert peak < 10 * 1024 * 1024  # peak memory under 10MB
+    assert sum(written_sizes) == 50 * 1024 * 1024
+    assert max(written_sizes) <= client.upload_buffer


### PR DESCRIPTION
## Summary
- Stream backup exports directly to rclone instead of buffering in memory
- Add memory consumption test for large uploads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ee35b5a08332baf92d005c324033