### PR TITLE
Fix Optional import and handle optional Drive folder

### DIFF
--- a/orchestrator/scheduler/__init__.py
+++ b/orchestrator/scheduler/__init__.py
@@ -34,7 +34,10 @@ def run_backup(app_id: int) -> None:
             return
     client = BackupClient(app.url, app.token)
     if client.check_capabilities():
-        client.export_backup(app.name, app.drive_folder_id)
+        if app.drive_folder_id:
+            client.export_backup(app.name, app.drive_folder_id)
+        else:
+            client.export_backup(app.name)
 
 
 def start() -> None:

--- a/orchestrator/services/client.py
+++ b/orchestrator/services/client.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import Iterable
+from typing import Iterable, Optional
 import requests
 
 


### PR DESCRIPTION
## Summary
- import `Optional` in BackupClient to prevent NameError
- call `export_backup` with Drive folder id only when provided

## Testing
- `make lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4f109a19883329dc5a547b3b8dc7a