### PR TITLE
Add schedule field for app registration

### DIFF
--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -2,6 +2,7 @@ import os
 from flask import Flask, render_template, request, jsonify
 from dotenv import load_dotenv
 from sqlalchemy import inspect, text
+from apscheduler.triggers.cron import CronTrigger
 
 from .database import Base, SessionLocal, engine
 from .models import App
@@ -51,11 +52,17 @@ def create_app() -> Flask:
         data = request.get_json(force=True)
         if not data:
             return {"error": "invalid payload"}, 400
+        schedule = data.get("schedule") or None
+        if schedule:
+            try:
+                CronTrigger.from_crontab(schedule)
+            except ValueError:
+                return {"error": "invalid schedule"}, 400
         new_app = App(
             name=data.get("name"),
             url=data.get("url"),
             token=data.get("token"),
-            schedule=data.get("schedule"),
+            schedule=schedule,
             drive_folder_id=data.get("drive_folder_id"),
             retention=data.get("retention"),
         )

--- a/orchestrator/app/static/js/app.js
+++ b/orchestrator/app/static/js/app.js
@@ -5,7 +5,7 @@ async function loadApps() {
   tbody.innerHTML = '';
   apps.forEach(app => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${app.name}</td><td>${app.url}</td><td>${app.token}</td><td>${app.drive_folder_id ?? ''}</td><td>${app.retention ?? ''}</td>`;
+    tr.innerHTML = `<td>${app.name}</td><td>${app.url}</td><td>${app.token}</td><td>${app.schedule ?? ''}</td><td>${app.drive_folder_id ?? ''}</td><td>${app.retention ?? ''}</td>`;
     tbody.appendChild(tr);
   });
 }
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
       name: document.getElementById('name').value,
       url: document.getElementById('url').value,
       token: document.getElementById('token').value,
+      schedule: document.getElementById('schedule').value || null,
       drive_folder_id: document.getElementById('drive_folder_id').value,
       retention: document.getElementById('retention').value ? parseInt(document.getElementById('retention').value, 10) : null
     };

--- a/orchestrator/app/templates/app_form.html
+++ b/orchestrator/app/templates/app_form.html
@@ -20,6 +20,10 @@
             <input type="text" class="form-control" id="token" required>
           </div>
           <div class="mb-3">
+            <label for="schedule" class="form-label">Schedule</label>
+            <input type="text" class="form-control" id="schedule" placeholder="* * * * *">
+          </div>
+          <div class="mb-3">
             <label for="drive_folder_id" class="form-label">Drive Folder ID</label>
             <input type="text" class="form-control" id="drive_folder_id">
           </div>

--- a/orchestrator/app/templates/index.html
+++ b/orchestrator/app/templates/index.html
@@ -5,7 +5,7 @@
   <h1 class="mb-4">Registered Apps</h1>
   <table class="table" id="apps-table">
     <thead>
-      <tr><th>Name</th><th>URL</th><th>Token</th><th>Drive Folder ID</th><th>Retention</th></tr>
+      <tr><th>Name</th><th>URL</th><th>Token</th><th>Schedule</th><th>Drive Folder ID</th><th>Retention</th></tr>
     </thead>
     <tbody></tbody>
   </table>

--- a/tests/test_app_schedule.py
+++ b/tests/test_app_schedule.py
@@ -1,0 +1,48 @@
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    from orchestrator import app as app_module
+    importlib.reload(app_module)
+    monkeypatch.setattr(app_module, "start_scheduler", lambda: None)
+    monkeypatch.setattr(app_module, "schedule_app_backups", lambda: None)
+    flask_app = app_module.create_app()
+    flask_app.config["TESTING"] = True
+    with flask_app.test_client() as client:
+        yield client
+
+
+def test_register_app_with_schedule(client):
+    resp = client.post(
+        "/apps",
+        json={
+            "name": "myapp",
+            "url": "http://example",
+            "token": "tok",
+            "schedule": "* * * * *",
+        },
+    )
+    assert resp.status_code == 201
+    resp = client.get("/apps")
+    assert resp.status_code == 200
+    apps = resp.get_json()
+    assert apps[0]["schedule"] == "* * * * *"
+
+
+def test_register_app_invalid_schedule(client):
+    resp = client.post(
+        "/apps",
+        json={
+            "name": "bad",
+            "url": "http://example",
+            "token": "tok",
+            "schedule": "invalid",
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "invalid schedule"


### PR DESCRIPTION
## Summary
- add schedule field to app registration form and API payload
- validate cron schedule when registering apps
- display schedule column on index and support scheduling in JS
- test app registration with cron schedule

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5b8a59c948332a769b6f61820a347