### PR TITLE
feat: support drive folder for backups

### DIFF
--- a/orchestrator/services/client.py
+++ b/orchestrator/services/client.py
@@ -33,11 +33,17 @@ class BackupClient:
             timeout=300,
         )
         resp.raise_for_status()
-        self._upload_stream_to_drive(resp.iter_content(64 * 1024), f"{app_name}.bak")
+        self._upload_stream_to_drive(
+            resp.iter_content(64 * 1024), f"{app_name}.bak", drive_folder_id
+        )
 
-    def _upload_stream_to_drive(self, chunks: Iterable[bytes], filename: str) -> None:
+    def _upload_stream_to_drive(
+        self, chunks: Iterable[bytes], filename: str, drive_folder_id: Optional[str] = None
+    ) -> None:
         """Upload an iterable of bytes to Google Drive using rclone rcat."""
         remote = os.environ.get("RCLONE_REMOTE", "drive:")
+        if drive_folder_id:
+            remote = f"{remote}{drive_folder_id.rstrip('/')}/"
         cmd = ["rclone", "rcat", f"{remote}{filename}"]
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
         if proc.stdin is None:

--- a/tests/test_client_upload.py
+++ b/tests/test_client_upload.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 import tracemalloc
+import requests
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from orchestrator.services.client import BackupClient
@@ -43,3 +44,64 @@ def test_upload_stream_large_file_memory(monkeypatch):
     assert peak < 10 * 1024 * 1024  # peak memory under 10MB
     assert sum(written_sizes) == 50 * 1024 * 1024
     assert max(written_sizes) <= client.upload_buffer
+
+
+def test_upload_stream_remote_path(monkeypatch):
+    client = BackupClient("http://example", "token")
+    cmds: list[list[str]] = []
+
+    class DummyStdin:
+        def write(self, data):
+            pass
+
+        def close(self):
+            pass
+
+    class DummyProcess:
+        def __init__(self):
+            self.stdin = DummyStdin()
+
+        def wait(self):
+            return 0
+
+    def fake_popen(cmd, stdin, **kwargs):
+        cmds.append(cmd)
+        return DummyProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    client._upload_stream_to_drive([b"x"], "test.bak", "folder")
+    assert cmds[-1][2] == "drive:folder/test.bak"
+
+    monkeypatch.setenv("RCLONE_REMOTE", "drive:base/")
+    client._upload_stream_to_drive([b"x"], "root.bak")
+    assert cmds[-1][2] == "drive:base/root.bak"
+
+
+def test_export_backup_passes_folder(monkeypatch):
+    client = BackupClient("http://example", "token")
+
+    def fake_post(url, headers, stream, timeout):
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def iter_content(self, chunk_size):
+                yield b"data"
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    called = {}
+
+    def fake_upload(chunks, filename, drive_folder_id):
+        called["filename"] = filename
+        called["drive_folder_id"] = drive_folder_id
+
+    monkeypatch.setattr(client, "_upload_stream_to_drive", fake_upload)
+
+    client.export_backup("myapp", "folderX")
+
+    assert called["filename"] == "myapp.bak"
+    assert called["drive_folder_id"] == "folderX"


### PR DESCRIPTION
## Summary
- allow export_backup to receive an optional Drive folder and forward it to uploads
- build rclone remote path using provided folder
- test remote path construction and parameter forwarding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5b8aaf1748332bb1c52ddfb735446