### PR TITLE
feat: add backup retention management

### DIFF
--- a/orchestrator/scheduler/__init__.py
+++ b/orchestrator/scheduler/__init__.py
@@ -35,9 +35,9 @@ def run_backup(app_id: int) -> None:
     client = BackupClient(app.url, app.token)
     if client.check_capabilities():
         if app.drive_folder_id:
-            client.export_backup(app.name, app.drive_folder_id)
+            client.export_backup(app.name, app.drive_folder_id, app.retention)
         else:
-            client.export_backup(app.name)
+            client.export_backup(app.name, retention=app.retention)
 
 
 def start() -> None:

--- a/orchestrator/services/client.py
+++ b/orchestrator/services/client.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import subprocess
 from typing import Iterable, Optional
@@ -24,8 +25,16 @@ class BackupClient:
         data = resp.json()
         return data.get("ready", False)
 
-    def export_backup(self, app_name: str, drive_folder_id: Optional[str] = None) -> None:
-        """Request backup export and upload the result to Google Drive."""
+    def export_backup(
+        self,
+        app_name: str,
+        drive_folder_id: Optional[str] = None,
+        retention: Optional[int] = None,
+    ) -> None:
+        """Request backup export and upload the result to Google Drive.
+
+        After uploading, apply retention policy if ``retention`` is provided.
+        """
         resp = requests.post(
             f"{self.base_url}/backup/export",
             headers=self._headers(),
@@ -33,7 +42,11 @@ class BackupClient:
             timeout=300,
         )
         resp.raise_for_status()
-        self._upload_stream_to_drive(resp.iter_content(64 * 1024), f"{app_name}.bak")
+        timestamp = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        filename = f"{app_name}_{timestamp}.bak"
+        self._upload_stream_to_drive(resp.iter_content(64 * 1024), filename)
+        if retention:
+            self.apply_retention(app_name, retention)
 
     def _upload_stream_to_drive(self, chunks: Iterable[bytes], filename: str) -> None:
         """Upload an iterable of bytes to Google Drive using rclone rcat."""
@@ -51,4 +64,33 @@ class BackupClient:
             returncode = proc.wait()
         if returncode != 0:
             raise RuntimeError(f"rclone exited with status {returncode}")
+
+    def apply_retention(self, app_name: str, retention: int) -> None:
+        """Remove old backups exceeding the retention count for the given app."""
+        if retention <= 0:
+            return
+        remote = os.environ.get("RCLONE_REMOTE", "drive:")
+        result = subprocess.run(
+            ["rclone", "lsl", remote],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        lines = [l for l in result.stdout.splitlines() if l.strip()]
+        backups: list[tuple[datetime.datetime, str]] = []
+        for line in lines:
+            parts = line.split(None, 3)
+            if len(parts) < 4:
+                continue
+            _, date, time, name = parts
+            if not name.startswith(f"{app_name}_"):
+                continue
+            try:
+                dt = datetime.datetime.fromisoformat(f"{date}T{time}")
+            except ValueError:
+                continue
+            backups.append((dt, name))
+        backups.sort(reverse=True)
+        for _, name in backups[retention:]:
+            subprocess.run(["rclone", "delete", f"{remote}{name}"], check=True)
 

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,53 @@
+import subprocess
+from types import SimpleNamespace
+
+from orchestrator.services.client import BackupClient
+
+
+def test_apply_retention_deletes_old(monkeypatch):
+    client = BackupClient("http://url", "token")
+    monkeypatch.setenv("RCLONE_REMOTE", "drive:")
+    deleted: list[str] = []
+
+    def fake_run(cmd, capture_output=False, text=False, check=False):
+        if cmd[:2] == ["rclone", "lsl"]:
+            return SimpleNamespace(
+                stdout=(
+                    "100 2024-01-01 00:00:00 app_20240101.bak\n"
+                    "100 2024-01-02 00:00:00 app_20240102.bak\n"
+                    "100 2024-01-03 00:00:00 app_20240103.bak\n"
+                ),
+                returncode=0,
+            )
+        elif cmd[:2] == ["rclone", "delete"]:
+            deleted.append(cmd[2])
+            return SimpleNamespace(returncode=0, stdout="")
+        raise AssertionError("unexpected command")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    client.apply_retention("app", 2)
+    assert deleted == ["drive:app_20240101.bak"]
+
+
+def test_apply_retention_no_delete(monkeypatch):
+    client = BackupClient("http://url", "token")
+    monkeypatch.setenv("RCLONE_REMOTE", "drive:")
+    deleted: list[str] = []
+
+    def fake_run(cmd, capture_output=False, text=False, check=False):
+        if cmd[:2] == ["rclone", "lsl"]:
+            return SimpleNamespace(
+                stdout=(
+                    "100 2024-01-01 00:00:00 app_20240101.bak\n"
+                    "100 2024-01-02 00:00:00 app_20240102.bak\n"
+                ),
+                returncode=0,
+            )
+        elif cmd[:2] == ["rclone", "delete"]:
+            deleted.append(cmd[2])
+            return SimpleNamespace(returncode=0, stdout="")
+        raise AssertionError("unexpected command")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    client.apply_retention("app", 5)
+    assert deleted == []


### PR DESCRIPTION
## Summary
- generate timestamped backup files and prune old ones based on app retention
- hook retention logic into scheduler
- add tests for rclone-based retention behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bea68d388332905546c65a0ff3c8