### PR TITLE
Add per-app rclone remote override

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ BACKUP_MAX_SIZE_MB=20480
 
 # rclone
 RCLONE_REMOTE=gdrive
+# Remote por defecto si la app no especifica uno propio
 # Cada app elige su carpeta destino; el orquestador guarda el folderId por app
 ```
 
@@ -81,6 +82,7 @@ En **Apps → Agregar**:
 - **URL interna**: `http://NOMBRE_DEL_CONTENEDOR:PUERTO` (gracias a `backups_net`).
 - **Token** (PSK) que valida la app.
 - **Destino en nube**: Folder ID de Drive.
+- **Remote rclone**: (opcional) para usar un remote distinto al global.
 - **Frecuencia** (diario/semanal) y **retención** (p.ej. 7 diarios, 4 semanales).
 
 Luego, **Probar ahora**. Deberías ver un archivo `NOMBRE_YYYYmmdd_HHMM.dump` en la carpeta de Drive.

--- a/docs/registro_de_apps.md
+++ b/docs/registro_de_apps.md
@@ -35,14 +35,16 @@ cada app.
        "url": "http://mi-app:8000",
        "token": "secreto-compartido",
        "drive_folder_id": "1AbC2dEfG3",
+       "rclone_remote": "gdrive:",
        "schedule": "0 3 * * *",
        "retention": 7
-     }
-     ```
-   - Respuesta (`201 Created`):
-     ```json
-     { "id": "mi-app", "status": "registered" }
-     ```
+      }
+      ```
+    - El campo `rclone_remote` es opcional y permite usar un remote específico en lugar del global.
+    - Respuesta (`201 Created`):
+      ```json
+      { "id": "mi-app", "status": "registered" }
+      ```
    - También se puede registrar desde la interfaz web como se describe en el
      [README](../README.md#7-registrar-una-app-en-la-ui).
 

--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -18,6 +18,8 @@ def create_app() -> Flask:
     with engine.begin() as conn:
         if "drive_folder_id" not in columns:
             conn.execute(text("ALTER TABLE apps ADD COLUMN drive_folder_id VARCHAR"))
+        if "rclone_remote" not in columns:
+            conn.execute(text("ALTER TABLE apps ADD COLUMN rclone_remote VARCHAR"))
         if "retention" not in columns:
             conn.execute(text("ALTER TABLE apps ADD COLUMN retention INTEGER"))
     start_scheduler()
@@ -39,6 +41,7 @@ def create_app() -> Flask:
                     "token": a.token,
                     "schedule": a.schedule,
                     "drive_folder_id": a.drive_folder_id,
+                    "rclone_remote": a.rclone_remote,
                     "retention": a.retention,
 
                 }
@@ -57,6 +60,7 @@ def create_app() -> Flask:
             token=data.get("token"),
             schedule=data.get("schedule"),
             drive_folder_id=data.get("drive_folder_id"),
+            rclone_remote=data.get("rclone_remote"),
             retention=data.get("retention"),
         )
         with SessionLocal() as db:

--- a/orchestrator/app/models.py
+++ b/orchestrator/app/models.py
@@ -14,5 +14,7 @@ class App(Base):
     schedule = Column(String, nullable=True)
     # Google Drive folder ID where backups will be stored
     drive_folder_id = Column(String, nullable=True)
+    # Optional rclone remote override
+    rclone_remote = Column(String, nullable=True)
     # Number of backups to retain
     retention = Column(Integer, nullable=True)

--- a/orchestrator/app/static/js/app.js
+++ b/orchestrator/app/static/js/app.js
@@ -5,7 +5,7 @@ async function loadApps() {
   tbody.innerHTML = '';
   apps.forEach(app => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${app.name}</td><td>${app.url}</td><td>${app.token}</td><td>${app.drive_folder_id ?? ''}</td><td>${app.retention ?? ''}</td>`;
+    tr.innerHTML = `<td>${app.name}</td><td>${app.url}</td><td>${app.token}</td><td>${app.drive_folder_id ?? ''}</td><td>${app.rclone_remote ?? ''}</td><td>${app.retention ?? ''}</td>`;
     tbody.appendChild(tr);
   });
 }
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
       url: document.getElementById('url').value,
       token: document.getElementById('token').value,
       drive_folder_id: document.getElementById('drive_folder_id').value,
+      rclone_remote: document.getElementById('rclone_remote').value,
       retention: document.getElementById('retention').value ? parseInt(document.getElementById('retention').value, 10) : null
     };
     const resp = await fetch('/apps', {

--- a/orchestrator/app/templates/app_form.html
+++ b/orchestrator/app/templates/app_form.html
@@ -24,6 +24,10 @@
             <input type="text" class="form-control" id="drive_folder_id">
           </div>
           <div class="mb-3">
+            <label for="rclone_remote" class="form-label">Rclone Remote</label>
+            <input type="text" class="form-control" id="rclone_remote">
+          </div>
+          <div class="mb-3">
             <label for="retention" class="form-label">Retention</label>
             <input type="number" class="form-control" id="retention" min="0">
           </div>

--- a/orchestrator/app/templates/index.html
+++ b/orchestrator/app/templates/index.html
@@ -5,7 +5,7 @@
   <h1 class="mb-4">Registered Apps</h1>
   <table class="table" id="apps-table">
     <thead>
-      <tr><th>Name</th><th>URL</th><th>Token</th><th>Drive Folder ID</th><th>Retention</th></tr>
+      <tr><th>Name</th><th>URL</th><th>Token</th><th>Drive Folder ID</th><th>Remote</th><th>Retention</th></tr>
     </thead>
     <tbody></tbody>
   </table>

--- a/orchestrator/scheduler/__init__.py
+++ b/orchestrator/scheduler/__init__.py
@@ -34,10 +34,11 @@ def run_backup(app_id: int) -> None:
             return
     client = BackupClient(app.url, app.token)
     if client.check_capabilities():
+        remote = app.rclone_remote
         if app.drive_folder_id:
-            client.export_backup(app.name, app.drive_folder_id)
+            client.export_backup(app.name, app.drive_folder_id, remote)
         else:
-            client.export_backup(app.name)
+            client.export_backup(app.name, None, remote)
 
 
 def start() -> None:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -40,8 +40,10 @@ def test_run_backup_exports(monkeypatch, test_session):
             called["checked"] = True
             return True
 
-        def export_backup(self, name: str) -> None:
-            called["exported"] = name
+        def export_backup(
+            self, name: str, drive_folder_id=None, remote=None
+        ) -> None:
+            called["exported"] = (name, drive_folder_id, remote)
 
     monkeypatch.setattr(scheduler, "BackupClient", DummyClient)
 
@@ -49,7 +51,7 @@ def test_run_backup_exports(monkeypatch, test_session):
 
     assert called["init"] == (app.url, app.token)
     assert called["checked"]
-    assert called["exported"] == app.name
+    assert called["exported"] == (app.name, None, None)
 
 
 def test_run_backup_missing_app(monkeypatch, test_session):
@@ -64,7 +66,9 @@ def test_run_backup_missing_app(monkeypatch, test_session):
         def check_capabilities(self) -> bool:
             return True
 
-        def export_backup(self, name: str) -> None:  # pragma: no cover - not expected
+        def export_backup(
+            self, name: str, drive_folder_id=None, remote=None
+        ) -> None:  # pragma: no cover - not expected
             pass
 
     monkeypatch.setattr(scheduler, "BackupClient", DummyClient)


### PR DESCRIPTION
## Summary
- allow apps to specify an optional `rclone_remote`
- use per-app remote when uploading backups
- expose remote field in UI and API documentation

## Testing
- `ruff check orchestrator/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bea9bb5c833298341f85d465affe