### PR TITLE
feat: add rclone authorization endpoint

### DIFF
--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from flask import Flask, render_template, request, jsonify
 from dotenv import load_dotenv
 from sqlalchemy import inspect, text
@@ -7,6 +8,7 @@ from apscheduler.triggers.cron import CronTrigger
 from .database import Base, SessionLocal, engine
 from .models import App
 from orchestrator.scheduler import start as start_scheduler, schedule_app_backups
+from orchestrator.services.rclone import authorize_drive
 
 
 def create_app() -> Flask:
@@ -75,6 +77,20 @@ def create_app() -> Flask:
             db.commit()
         schedule_app_backups()
         return {"status": "ok"}, 201
+
+    @app.post("/rclone/remotes/<name>/authorize")
+    def authorize_remote(name: str):
+        """Initiate or complete authorization for an rclone remote."""
+        data = request.get_json(silent=True) or {}
+        token = data.get("token")
+        if token:
+            subprocess.run(
+                ["rclone", "config", "update", name, "token", token],
+                check=True,
+            )
+            return {"status": "ok"}, 200
+        url = authorize_drive()
+        return {"url": url}, 200
 
     return app
 

--- a/orchestrator/services/client.py
+++ b/orchestrator/services/client.py
@@ -44,13 +44,6 @@ class BackupClient:
         self,
         app_name: str,
         drive_folder_id: Optional[str] = None,
-        retention: Optional[int] = None,
-    ) -> None:
-        """Request backup export and upload the result to Google Drive.
-    def export_backup(
-        self,
-        app_name: str,
-        drive_folder_id: Optional[str] = None,
         remote: Optional[str] = None,
     ) -> None:
         """Request backup export and upload the result to Google Drive."""

--- a/orchestrator/services/rclone.py
+++ b/orchestrator/services/rclone.py
@@ -1,0 +1,37 @@
+import re
+import subprocess
+
+
+def authorize_drive() -> str:
+    """Run ``rclone authorize "drive"`` and return the authorization URL.
+
+    The command normally prints a line containing the URL the user must open in
+    their browser. This helper captures the output, extracts the first URL and
+    terminates the process once found.
+    """
+    proc = subprocess.Popen(
+        ["rclone", "authorize", "drive"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if proc.stdout is None:
+        proc.kill()
+        raise RuntimeError("failed to capture rclone output")
+
+    url: str | None = None
+    try:
+        for line in proc.stdout:
+            match = re.search(r"https?://\S+", line)
+            if match:
+                url = match.group(0)
+                break
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    if not url:
+        raise RuntimeError("authorization URL not found")
+    return url

--- a/tests/test_rclone_authorize.py
+++ b/tests/test_rclone_authorize.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import subprocess
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+from orchestrator.app import create_app
+
+
+def test_authorize_returns_url(monkeypatch):
+    monkeypatch.setattr("orchestrator.app.start_scheduler", lambda: None)
+    monkeypatch.setattr("orchestrator.app.authorize_drive", lambda: "http://auth")
+    app = create_app()
+    client = app.test_client()
+    resp = client.post("/rclone/remotes/foo/authorize", json={})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"url": "http://auth"}
+
+
+def test_authorize_updates_config(monkeypatch):
+    monkeypatch.setattr("orchestrator.app.start_scheduler", lambda: None)
+
+    def fail():
+        raise AssertionError("authorize_drive should not be called")
+
+    monkeypatch.setattr("orchestrator.app.authorize_drive", fail)
+    called: dict[str, list[str]] = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    app = create_app()
+    client = app.test_client()
+    resp = client.post("/rclone/remotes/foo/authorize", json={"token": "tkn"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+    assert called["cmd"] == ["rclone", "config", "update", "foo", "token", "tkn"]


### PR DESCRIPTION
## Summary
- add helper to run `rclone authorize drive` and return auth URL
- expose `POST /rclone/remotes/:name/authorize` to return URL or save token via `rclone config update`
- fix BackupClient export helper and cover endpoint with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ffcca9708332b75e60be9a0aa0d6