### PR TITLE
docs: agregar guía de uso de la UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Orquestador liviano que:
 - Pide el backup por HTTP al endpoint de la app y **sube a la nube** (inicio: Google Drive).
 - Aplica **retención**, guarda **logs** y permite **“Probar ahora”**.
 
+> Para una introducción paso a paso a la interfaz web, consultá la [Guía de uso de la UI](docs/ui_usage.md).
+
 ---
 
 

--- a/docs/ui_usage.md
+++ b/docs/ui_usage.md
@@ -1,0 +1,34 @@
+# Guía de uso de la interfaz web
+
+Esta guía resume los pasos básicos para operar la UI del orquestador de backups.
+
+## 1. Acceder y autenticarse
+1. Levantar el proyecto con Docker (`docker compose up -d`).
+2. Abrir `http://localhost:5550` (o el puerto configurado en `APP_PORT`).
+3. Ingresar con las credenciales definidas en las variables `APP_ADMIN_USER` y `APP_ADMIN_PASS`.
+
+## 2. Configurar rclone
+1. Desde el menú **Rclone → Configurar**, seguir el asistente interactivo para crear un *remote* (p.ej. `gdrive`).
+2. Una vez configurado, verificar los remotes disponibles en **Rclone → Remotes**.
+
+## 3. Registrar una aplicación
+1. Ir a **Apps → Agregar**.
+2. Completar:
+   - **Nombre** de la app.
+   - **URL interna** accesible desde la red `backups_net`.
+   - **Token** (PSK) para autenticar contra la app.
+   - **Folder ID** de Google Drive donde guardar los respaldos.
+   - Opcional: *remote* distinto si la app no utiliza el global.
+   - Frecuencia y política de retención.
+3. Guardar y utilizar **Probar ahora** para forzar un primer respaldo.
+
+## 4. Consultar logs y backups
+- Cada ejecución registra su resultado en la tabla de eventos.
+- Los logs completos pueden verse desde **Logs** en la barra superior.
+- Los archivos subidos se listan en la sección de cada app.
+
+## 5. Administración adicional
+- Editar o eliminar apps desde **Apps → Lista**.
+- Ajustar variables globales reiniciando el contenedor con nuevos valores en `.env`.
+
+Esta guía cubre las operaciones comunes. Para detalles del contrato de respaldo y configuración avanzada consulte [`registro_de_apps.md`](registro_de_apps.md).


### PR DESCRIPTION
## Summary
- documentar pasos para operar la interfaz web
- enlazar README a la guía de UI

## Testing
- `make lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6054c6f2483329213aee0baab22f4