### PR TITLE
feat: secure ui and manage remotes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,17 @@
+# Base de datos
 DATABASE_URL=sqlite:///./apps.db
+
+# UI y seguridad
 PORT=5550
+APP_SECRET_KEY=poné_una_clave_larga
+APP_ADMIN_USER=admin
+APP_ADMIN_PASS=cambiame
+
+# Límites/tiempos
+REQUEST_TIMEOUT_S=900
+BACKUP_MAX_SIZE_MB=20480
+
+# rclone
+RCLONE_REMOTE=gdrive
+# Remote por defecto si la app no especifica uno propio
+# Cada app elige su carpeta destino; el orquestador guarda el folderId por app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,24 @@ services:
   orchestrator:
     build: .
     container_name: backuper
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      PORT: ${PORT}
+      APP_SECRET_KEY: ${APP_SECRET_KEY}
+      APP_ADMIN_USER: ${APP_ADMIN_USER}
+      APP_ADMIN_PASS: ${APP_ADMIN_PASS}
+      REQUEST_TIMEOUT_S: ${REQUEST_TIMEOUT_S}
+      BACKUP_MAX_SIZE_MB: ${BACKUP_MAX_SIZE_MB}
+      RCLONE_REMOTE: ${RCLONE_REMOTE}
     volumes:
       - backups:/backups
     networks:
       - backups_net
       - cloudflared_net
+    ports:
+      - "${PORT}:${PORT}"
 volumes:
   backups:
 networks:

--- a/orchestrator/app/static/js/app.js
+++ b/orchestrator/app/static/js/app.js
@@ -1,5 +1,9 @@
 async function loadApps() {
   const resp = await fetch('/apps');
+  if (resp.status === 401) {
+    window.location.href = '/login';
+    return;
+  }
   const apps = await resp.json();
   const tbody = document.querySelector('#apps-table tbody');
   tbody.innerHTML = '';
@@ -29,6 +33,10 @@ document.addEventListener('DOMContentLoaded', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     });
+    if (resp.status === 401) {
+      window.location.href = '/login';
+      return;
+    }
     if (resp.ok) {
       e.target.reset();
       const modal = bootstrap.Modal.getInstance(document.getElementById('appModal'));

--- a/orchestrator/app/static/js/remotes.js
+++ b/orchestrator/app/static/js/remotes.js
@@ -1,5 +1,9 @@
 async function loadRemotes() {
   const resp = await fetch('/rclone/remotes');
+  if (resp.status === 401) {
+    window.location.href = '/login';
+    return;
+  }
   const remotes = await resp.json();
   const tbody = document.querySelector('#remotes-table tbody');
   if (tbody) {
@@ -39,6 +43,10 @@ document.addEventListener('DOMContentLoaded', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
+      if (resp.status === 401) {
+        window.location.href = '/login';
+        return;
+      }
       if (resp.ok) {
         form.reset();
         loadRemotes();

--- a/orchestrator/app/templates/base.html
+++ b/orchestrator/app/templates/base.html
@@ -9,7 +9,9 @@
   <body>
     {% block content %}{% endblock %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    {% block scripts %}
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="{{ url_for('static', filename='js/remotes.js') }}"></script>
+    {% endblock %}
   </body>
 </html>

--- a/orchestrator/app/templates/login.html
+++ b/orchestrator/app/templates/login.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container py-4">
+  <h1 class="mb-4">Login</h1>
+  {% if error %}
+  <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+  <form method="post">
+    <div class="mb-3">
+      <label for="username" class="form-label">Username</label>
+      <input type="text" class="form-control" id="username" name="username" required>
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Password</label>
+      <input type="password" class="form-control" id="password" name="password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+  </form>
+  </div>
+  {% endblock %}
+  {% block scripts %}{% endblock %}

--- a/tests/test_app_schedule.py
+++ b/tests/test_app_schedule.py
@@ -6,6 +6,9 @@ import pytest
 def client(monkeypatch, tmp_path):
     db_path = tmp_path / "test.db"
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("APP_ADMIN_USER", "admin")
+    monkeypatch.setenv("APP_ADMIN_PASS", "secret")
+    monkeypatch.setenv("APP_SECRET_KEY", "test-key")
     from orchestrator import app as app_module
     from orchestrator.app import database as db_module
     from orchestrator.app import models as models_module
@@ -17,6 +20,7 @@ def client(monkeypatch, tmp_path):
     flask_app = app_module.create_app()
     flask_app.config["TESTING"] = True
     with flask_app.test_client() as client:
+        client.post("/login", data={"username": "admin", "password": "secret"})
         yield client
 
 

--- a/tests/test_rclone_api.py
+++ b/tests/test_rclone_api.py
@@ -10,6 +10,9 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 @pytest.fixture
 def app(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "sqlite://")
+    monkeypatch.setenv("APP_ADMIN_USER", "admin")
+    monkeypatch.setenv("APP_ADMIN_PASS", "secret")
+    monkeypatch.setenv("APP_SECRET_KEY", "test-key")
     app_module = importlib.import_module("orchestrator.app")
     db_module = importlib.import_module("orchestrator.app.database")
     models_module = importlib.import_module("orchestrator.app.models")
@@ -35,6 +38,7 @@ def test_list_rclone_remotes(monkeypatch, app):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     client = app.test_client()
+    client.post("/login", data={"username": "admin", "password": "secret"})
     resp = client.get("/rclone/remotes")
     assert resp.status_code == 200
     assert resp.get_json() == ["gdrive", "other"]
@@ -49,6 +53,7 @@ def test_register_app_with_remote(monkeypatch, app):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     client = app.test_client()
+    client.post("/login", data={"username": "admin", "password": "secret"})
     payload = {
         "name": "remoteapp",
         "url": "http://remoteapp",

--- a/tests/test_rclone_authorize.py
+++ b/tests/test_rclone_authorize.py
@@ -4,6 +4,9 @@ import subprocess
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["APP_ADMIN_USER"] = "admin"
+os.environ["APP_ADMIN_PASS"] = "secret"
+os.environ["APP_SECRET_KEY"] = "test-key"
 
 from orchestrator.app import create_app
 
@@ -13,6 +16,7 @@ def test_authorize_returns_url(monkeypatch):
     monkeypatch.setattr("orchestrator.app.authorize_drive", lambda: "http://auth")
     app = create_app()
     client = app.test_client()
+    client.post("/login", data={"username": "admin", "password": "secret"})
     resp = client.post("/rclone/remotes/foo/authorize", json={})
     assert resp.status_code == 200
     assert resp.get_json() == {"url": "http://auth"}
@@ -33,6 +37,7 @@ def test_authorize_updates_config(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fake_run)
     app = create_app()
     client = app.test_client()
+    client.post("/login", data={"username": "admin", "password": "secret"})
     resp = client.post("/rclone/remotes/foo/authorize", json={"token": "tkn"})
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add login and session handling based on admin credentials
- secure endpoints and allow creating rclone remotes
- redirect frontend fetches to login on 401 responses
- prevent login page scripts from causing redirect loops
- redirect anonymous visits to the root URL straight to the login form
- provide `.env.example` with all required environment settings
- load environment variables from `.env` in docker-compose and map the configured port

## Testing
- `pytest -q`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c60aceb44c8332be595ea859e2ac4d