### PR TITLE
Add UI menu, logout, and full UI features

### DIFF
--- a/orchestrator/app/static/js/app.js
+++ b/orchestrator/app/static/js/app.js
@@ -9,7 +9,15 @@ async function loadApps() {
   tbody.innerHTML = '';
   apps.forEach(app => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${app.name}</td><td>${app.url}</td><td>${app.token}</td><td>${app.drive_folder_id ?? ''}</td><td>${app.rclone_remote ?? ''}</td><td>${app.retention ?? ''}</td>`;
+    tr.dataset.id = app.id;
+    tr.dataset.name = app.name;
+    tr.dataset.url = app.url;
+    tr.dataset.token = app.token;
+    tr.dataset.schedule = app.schedule ?? '';
+    tr.dataset.driveFolderId = app.drive_folder_id ?? '';
+    tr.dataset.rcloneRemote = app.rclone_remote ?? '';
+    tr.dataset.retention = app.retention ?? '';
+    tr.innerHTML = `<td>${app.name}</td><td>${app.url}</td><td>${app.token}</td><td>${app.drive_folder_id ?? ''}</td><td>${app.rclone_remote ?? ''}</td><td>${app.retention ?? ''}</td><td><button class="btn btn-sm btn-secondary edit-btn">Edit</button> <button class="btn btn-sm btn-danger delete-btn">Delete</button> <button class="btn btn-sm btn-info run-btn">Run now</button></td>`;
     tbody.appendChild(tr);
   });
 }
@@ -17,8 +25,18 @@ async function loadApps() {
 document.addEventListener('DOMContentLoaded', () => {
   loadApps();
 
+  const addBtn = document.querySelector('[data-bs-target="#appModal"]');
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      document.getElementById('app-form').reset();
+      document.getElementById('app_id').value = '';
+      document.getElementById('appModalLabel').textContent = 'Register App';
+    });
+  }
+
   document.getElementById('app-form').addEventListener('submit', async (e) => {
     e.preventDefault();
+    const id = document.getElementById('app_id').value;
     const payload = {
       name: document.getElementById('name').value,
       url: document.getElementById('url').value,
@@ -28,8 +46,8 @@ document.addEventListener('DOMContentLoaded', () => {
       rclone_remote: document.getElementById('rclone_remote').value,
       retention: document.getElementById('retention').value ? parseInt(document.getElementById('retention').value, 10) : null
     };
-    const resp = await fetch('/apps', {
-      method: 'POST',
+    const resp = await fetch(id ? `/apps/${id}` : '/apps', {
+      method: id ? 'PUT' : 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     });
@@ -39,9 +57,50 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (resp.ok) {
       e.target.reset();
+      document.getElementById('app_id').value = '';
       const modal = bootstrap.Modal.getInstance(document.getElementById('appModal'));
       modal.hide();
       loadApps();
+    }
+  });
+
+  document.getElementById('apps-table').addEventListener('click', async (e) => {
+    const tr = e.target.closest('tr');
+    if (!tr) return;
+    const id = tr.dataset.id;
+    if (e.target.classList.contains('edit-btn')) {
+      document.getElementById('app_id').value = id;
+      document.getElementById('name').value = tr.dataset.name;
+      document.getElementById('url').value = tr.dataset.url;
+      document.getElementById('token').value = tr.dataset.token;
+      document.getElementById('schedule').value = tr.dataset.schedule;
+      document.getElementById('drive_folder_id').value = tr.dataset.driveFolderId;
+      document.getElementById('rclone_remote').value = tr.dataset.rcloneRemote;
+      document.getElementById('retention').value = tr.dataset.retention;
+      document.getElementById('appModalLabel').textContent = 'Edit App';
+      const modal = new bootstrap.Modal(document.getElementById('appModal'));
+      modal.show();
+    }
+    if (e.target.classList.contains('delete-btn')) {
+      if (!confirm('Delete this app?')) return;
+      const resp = await fetch(`/apps/${id}`, { method: 'DELETE' });
+      if (resp.status === 401) {
+        window.location.href = '/login';
+        return;
+      }
+      if (resp.ok) {
+        loadApps();
+      }
+    }
+    if (e.target.classList.contains('run-btn')) {
+      const resp = await fetch(`/apps/${id}/run`, { method: 'POST' });
+      if (resp.status === 401) {
+        window.location.href = '/login';
+        return;
+      }
+      if (resp.ok) {
+        alert('Backup started');
+      }
     }
   });
 });

--- a/orchestrator/app/static/js/remotes.js
+++ b/orchestrator/app/static/js/remotes.js
@@ -13,6 +13,10 @@ async function loadRemotes() {
   if (select) {
     select.innerHTML = '<option value=""></option>';
   }
+  const authSelect = document.getElementById('auth_remote');
+  if (authSelect) {
+    authSelect.innerHTML = '<option value=""></option>';
+  }
   remotes.forEach(name => {
     if (tbody) {
       const tr = document.createElement('tr');
@@ -24,6 +28,12 @@ async function loadRemotes() {
       opt.value = name;
       opt.textContent = name;
       select.appendChild(opt);
+    }
+    if (authSelect) {
+      const opt2 = document.createElement('option');
+      opt2.value = name;
+      opt2.textContent = name;
+      authSelect.appendChild(opt2);
     }
   });
 }
@@ -50,6 +60,45 @@ document.addEventListener('DOMContentLoaded', () => {
       if (resp.ok) {
         form.reset();
         loadRemotes();
+      }
+    });
+  }
+
+  const startBtn = document.getElementById('start-auth');
+  if (startBtn) {
+    startBtn.addEventListener('click', async () => {
+      const name = document.getElementById('auth_remote').value;
+      if (!name) return;
+      const resp = await fetch(`/rclone/remotes/${name}/authorize`);
+      if (resp.status === 401) {
+        window.location.href = '/login';
+        return;
+      }
+      const data = await resp.json();
+      if (data.url) {
+        window.open(data.url, '_blank');
+      }
+    });
+  }
+
+  const finishBtn = document.getElementById('finish-auth');
+  if (finishBtn) {
+    finishBtn.addEventListener('click', async () => {
+      const name = document.getElementById('auth_remote').value;
+      const token = document.getElementById('auth_token').value;
+      if (!name || !token) return;
+      const resp = await fetch(`/rclone/remotes/${name}/authorize`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token })
+      });
+      if (resp.status === 401) {
+        window.location.href = '/login';
+        return;
+      }
+      if (resp.ok) {
+        document.getElementById('auth_token').value = '';
+        alert('Remote authorized');
       }
     });
   }

--- a/orchestrator/app/templates/app_form.html
+++ b/orchestrator/app/templates/app_form.html
@@ -7,6 +7,7 @@
       </div>
       <div class="modal-body">
         <form id="app-form">
+          <input type="hidden" id="app_id">
           <div class="mb-3">
             <label for="name" class="form-label">Name</label>
             <input type="text" class="form-control" id="name" required>

--- a/orchestrator/app/templates/base.html
+++ b/orchestrator/app/templates/base.html
@@ -7,6 +7,36 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   </head>
   <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">Backup Orchestrator</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('index') }}">Apps</a>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="rcloneDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Rclone</a>
+              <ul class="dropdown-menu" aria-labelledby="rcloneDropdown">
+                <li><a class="dropdown-item" href="{{ url_for('rclone_config') }}">Configurar</a></li>
+                <li><a class="dropdown-item" href="{{ url_for('remotes') }}">Remotes</a></li>
+              </ul>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('logs') }}">Logs</a>
+            </li>
+          </ul>
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
     {% block content %}{% endblock %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     {% block scripts %}

--- a/orchestrator/app/templates/index.html
+++ b/orchestrator/app/templates/index.html
@@ -5,7 +5,7 @@
   <h1 class="mb-4">Registered Apps</h1>
   <table class="table" id="apps-table">
     <thead>
-      <tr><th>Name</th><th>URL</th><th>Token</th><th>Drive Folder ID</th><th>Remote</th><th>Retention</th></tr>
+      <tr><th>Name</th><th>URL</th><th>Token</th><th>Drive Folder ID</th><th>Remote</th><th>Retention</th><th>Actions</th></tr>
     </thead>
     <tbody></tbody>
   </table>

--- a/orchestrator/app/templates/logs.html
+++ b/orchestrator/app/templates/logs.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container py-4">
+  <h1 class="mb-4">Logs</h1>
+  <pre class="bg-light p-3 border" style="white-space: pre-wrap;">{{ logs }}</pre>
+</div>
+{% endblock %}

--- a/orchestrator/app/templates/rclone_config.html
+++ b/orchestrator/app/templates/rclone_config.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container py-4">
+  <h1 class="mb-4">Configurar Rclone</h1>
+  <form id="remote-form">
+    <div class="mb-3">
+      <label for="remote_name" class="form-label">Nombre</label>
+      <input type="text" class="form-control" id="remote_name" required>
+    </div>
+    <div class="mb-3">
+      <label for="remote_type" class="form-label">Tipo</label>
+      <input type="text" class="form-control" id="remote_type" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Guardar</button>
+  </form>
+  <h2 class="mt-5">Autorizar Remote</h2>
+  <div class="mb-3">
+    <label for="auth_remote" class="form-label">Remote</label>
+    <select class="form-select" id="auth_remote"></select>
+  </div>
+  <button id="start-auth" class="btn btn-secondary mb-3">Iniciar autorización</button>
+  <div class="mb-3">
+    <label for="auth_token" class="form-label">Token</label>
+    <textarea id="auth_token" class="form-control" rows="3"></textarea>
+  </div>
+  <button id="finish-auth" class="btn btn-primary">Finalizar autorización</button>
+</div>
+{% endblock %}

--- a/orchestrator/app/templates/remotes.html
+++ b/orchestrator/app/templates/remotes.html
@@ -9,17 +9,5 @@
     </thead>
     <tbody></tbody>
   </table>
-  <h2 class="mt-4">Add Remote</h2>
-  <form id="remote-form">
-    <div class="mb-3">
-      <label for="remote_name" class="form-label">Name</label>
-      <input type="text" class="form-control" id="remote_name" required>
-    </div>
-    <div class="mb-3">
-      <label for="remote_type" class="form-label">Type</label>
-      <input type="text" class="form-control" id="remote_type" required>
-    </div>
-    <button type="submit" class="btn btn-primary">Save</button>
-  </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Implement Bootstrap navbar with links for app list, rclone configuration/remotes, logs, and logout
- Enable full app management: create, edit, delete, and run backups from the UI
- Provide pages and scripts for rclone remote configuration/authorization and basic log viewing

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c61573891c8332a23d8f9a931781da