### PR TITLE
Install rclone in orchestrator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM python:3.11-slim
 
+# Install rclone binary for remote storage operations
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends rclone \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
-# Install dependencies
+# Install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/docs/ui_usage.md
+++ b/docs/ui_usage.md
@@ -40,11 +40,12 @@ funcionalidades ofrece cada sección.
 ## 3. Configurar rclone
 1. Ingresar a **Rclone → Configurar** para ejecutar el asistente `rclone config`
    directamente desde la UI.
-2. Completar **Nombre** y elegir el **Tipo** de backend (por ejemplo `drive`,
-   `s3`, `webdav`) desde el desplegable para crear un *remote*.
+2. Completar **Nombre** y elegir el **Tipo** de backend (`drive`,
+   `onedrive`, `sftp` o `local`) desde el desplegable para crear un *remote*.
 
 3. Los remotes existentes se listan en **Rclone → Remotes**, donde se puede
    comprobar que hayan quedado registrados correctamente.
+   - Para `sftp`, el contenedor puede alcanzar al host mediante `host.docker.internal` y se puede especificar el puerto `222` u otro durante la configuración.
 
 ## 4. Visor de logs
 - El enlace **Logs** muestra las últimas líneas del log del orquestador.

--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -150,6 +150,9 @@ def create_app() -> Flask:
         data = request.get_json(force=True)
         if not data or not data.get("name") or not data.get("type"):
             return {"error": "invalid payload"}, 400
+        allowed_types = {"drive", "onedrive", "sftp", "local"}
+        if data["type"] not in allowed_types:
+            return {"error": "unsupported remote type"}, 400
         try:
             run_rclone(["config", "create", data["name"], data["type"]], check=True)
         except RuntimeError:

--- a/orchestrator/app/templates/rclone_config.html
+++ b/orchestrator/app/templates/rclone_config.html
@@ -13,11 +13,7 @@
       <select class="form-select" id="remote_type" required>
         <option value="">Seleccione...</option>
         <option value="drive">drive (Google Drive)</option>
-        <option value="s3">s3 (Amazon S3)</option>
-        <option value="webdav">webdav</option>
-        <option value="dropbox">dropbox</option>
         <option value="onedrive">onedrive</option>
-        <option value="ftp">ftp</option>
         <option value="sftp">sftp</option>
         <option value="local">local</option>
       </select>

--- a/tests/test_rclone_api.py
+++ b/tests/test_rclone_api.py
@@ -92,3 +92,11 @@ def test_create_rclone_remote_missing_binary(monkeypatch, app):
     )
     assert resp.status_code == 500
     assert resp.get_json() == {"error": "rclone is not installed"}
+
+
+def test_create_rclone_remote_unsupported_type(app):
+    client = app.test_client()
+    client.post("/login", data={"username": "admin", "password": "secret"})
+    resp = client.post("/rclone/remotes", json={"name": "foo", "type": "s3"})
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "unsupported remote type"}


### PR DESCRIPTION
## Summary
- Install rclone via apt in Dockerfile so the orchestrator container has the binary available
- Limit rclone remote creation to drive, onedrive, sftp or local and document SFTP usage

## Testing
- `make lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6fb862f6c8332bc11eca3f77aea88