### PR TITLE
Add GET route for rclone authorization URL

### DIFF
--- a/tests/test_rclone_authorize.py
+++ b/tests/test_rclone_authorize.py
@@ -17,7 +17,7 @@ def test_authorize_returns_url(monkeypatch):
     app = create_app()
     client = app.test_client()
     client.post("/login", data={"username": "admin", "password": "secret"})
-    resp = client.post("/rclone/remotes/foo/authorize", json={})
+    resp = client.get("/rclone/remotes/foo/authorize")
     assert resp.status_code == 200
     assert resp.get_json() == {"url": "http://auth"}
 


### PR DESCRIPTION
## Summary
- add GET endpoint to initiate rclone remote authorization
- restrict POST /rclone/remotes/<name>/authorize to token submission
- update rclone authorization tests

## Testing
- `ruff check orchestrator/ tests/test_rclone_authorize.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c77998918483329a90bb347ec27301