### PR TITLE
Use GET for rclone remote authorization URL

### DIFF
--- a/orchestrator/app/static/js/remotes.js
+++ b/orchestrator/app/static/js/remotes.js
@@ -69,7 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
     startBtn.addEventListener('click', async () => {
       const name = document.getElementById('auth_remote').value;
       if (!name) return;
-      const resp = await fetch(`/rclone/remotes/${name}/authorize`, { method: 'POST' });
+      const resp = await fetch(`/rclone/remotes/${name}/authorize`);
       if (resp.status === 401) {
         window.location.href = '/login';
         return;


### PR DESCRIPTION
## Summary
- update the start authorization button to request the remote authorization URL with GET
- continue populating the authorization URL input, link, and container when a URL is returned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb156f65588332b5b698da8b247b54