### PR TITLE
Normalize rclone remotes before running commands

### DIFF
--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -21,6 +21,7 @@ from orchestrator.scheduler import (
     schedule_app_backups,
     run_backup,
 )
+from orchestrator.services.client import _normalize_remote
 from orchestrator.services.rclone import authorize_drive
 
 
@@ -201,9 +202,10 @@ def create_app() -> Flask:
             except RuntimeError:
                 return {"error": "rclone is not installed"}, 500
             available = [r.strip() for r in result.stdout.splitlines() if r.strip()]
-            normalized = remote if remote.endswith(":") else f"{remote}:"
+            normalized = _normalize_remote(remote)
             if normalized not in available:
                 return {"error": "unknown rclone remote"}, 400
+            remote = normalized
         new_app = App(
             name=data.get("name"),
             url=data.get("url"),
@@ -240,9 +242,10 @@ def create_app() -> Flask:
             except RuntimeError:
                 return {"error": "rclone is not installed"}, 500
             available = [r.strip() for r in result.stdout.splitlines() if r.strip()]
-            normalized = remote if remote.endswith(":") else f"{remote}:"
+            normalized = _normalize_remote(remote)
             if normalized not in available:
                 return {"error": "unknown rclone remote"}, 400
+            remote = normalized
         with SessionLocal() as db:
             app_obj = db.get(App, app_id)
             if not app_obj:

--- a/orchestrator/services/client.py
+++ b/orchestrator/services/client.py
@@ -2,7 +2,16 @@ import datetime
 import os
 import subprocess
 from typing import Iterable, Optional
+
 import requests
+
+
+def _normalize_remote(remote: str) -> str:
+    """Ensure an rclone remote name ends with a trailing colon."""
+
+    if not remote.endswith(":"):
+        return f"{remote}:"
+    return remote
 
 
 class BackupClient:
@@ -66,7 +75,7 @@ class BackupClient:
         self, chunks: Iterable[bytes], filename: str, remote: Optional[str] = None
     ) -> None:
         """Upload an iterable of bytes to Google Drive using rclone rcat."""
-        remote = remote or os.environ.get("RCLONE_REMOTE", "drive:")
+        remote = _normalize_remote(remote or os.environ.get("RCLONE_REMOTE", "drive:"))
         cmd = ["rclone", "rcat", f"{remote}{filename}"]
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
         if proc.stdin is None:
@@ -85,7 +94,7 @@ class BackupClient:
         """Remove old backups exceeding the retention count for the given app."""
         if retention <= 0:
             return
-        remote = os.environ.get("RCLONE_REMOTE", "drive:")
+        remote = _normalize_remote(os.environ.get("RCLONE_REMOTE", "drive:"))
         result = subprocess.run(
             ["rclone", "lsl", remote],
             capture_output=True,

--- a/tests/test_client_upload.py
+++ b/tests/test_client_upload.py
@@ -1,5 +1,4 @@
 import os
-import os
 import subprocess
 import sys
 import tracemalloc
@@ -13,21 +12,27 @@ def test_upload_stream_large_file_memory(monkeypatch):
     client = BackupClient("http://example", "token")
 
     written_sizes = []
+    monkeypatch.setenv("RCLONE_REMOTE", "drive")
+    captured_cmds = []
 
     class DummyStdin:
         def write(self, data):
             written_sizes.append(len(data))
+
         def close(self):
             pass
 
     class DummyProcess:
         def __init__(self):
             self.stdin = DummyStdin()
+
         def wait(self):
             return 0
 
     def fake_popen(cmd, stdin, **kwargs):
+        captured_cmds.append(cmd)
         assert cmd[:2] == ["rclone", "rcat"]
+        assert cmd[2] == "drive:big.bak"
         assert stdin == subprocess.PIPE
         return DummyProcess()
 
@@ -45,6 +50,9 @@ def test_upload_stream_large_file_memory(monkeypatch):
     assert peak < 10 * 1024 * 1024  # peak memory under 10MB
     assert sum(written_sizes) == 50 * 1024 * 1024
     assert max(written_sizes) <= client.upload_buffer
+    assert captured_cmds[0][2] == "drive:big.bak"
+
+
 def test_upload_stream_custom_remote(monkeypatch):
     client = BackupClient("http://example", "token")
 
@@ -61,15 +69,16 @@ def test_upload_stream_custom_remote(monkeypatch):
 
         def wait(self):
             return 0
+
     captured = {}
 
     def fake_popen(cmd, stdin, **kwargs):
         captured["cmd"] = cmd
-
+        assert cmd[:2] == ["rclone", "rcat"]
+        assert stdin == subprocess.PIPE
         return DummyProcess()
 
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
-    client._upload_stream_to_drive([b"data"], "test.bak", remote="custom:")
+    client._upload_stream_to_drive([b"data"], "test.bak", remote="custom")
 
     assert captured["cmd"][2] == "custom:test.bak"
-

--- a/tests/test_rclone_api.py
+++ b/tests/test_rclone_api.py
@@ -58,7 +58,7 @@ def test_register_app_with_remote(monkeypatch, app):
         "name": "remoteapp",
         "url": "http://remoteapp",
         "token": "tok",
-        "rclone_remote": "gdrive:",
+        "rclone_remote": "gdrive",
     }
     resp = client.post("/apps", json=payload)
     assert resp.status_code == 201

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -6,11 +6,12 @@ from orchestrator.services.client import BackupClient
 
 def test_apply_retention_deletes_old(monkeypatch):
     client = BackupClient("http://url", "token")
-    monkeypatch.setenv("RCLONE_REMOTE", "drive:")
+    monkeypatch.setenv("RCLONE_REMOTE", "drive")
     deleted: list[str] = []
 
     def fake_run(cmd, capture_output=False, text=False, check=False):
         if cmd[:2] == ["rclone", "lsl"]:
+            assert cmd[2] == "drive:"
             return SimpleNamespace(
                 stdout=(
                     "100 2024-01-01 00:00:00 app_20240101.bak\n"
@@ -20,6 +21,7 @@ def test_apply_retention_deletes_old(monkeypatch):
                 returncode=0,
             )
         elif cmd[:2] == ["rclone", "delete"]:
+            assert cmd[2].startswith("drive:")
             deleted.append(cmd[2])
             return SimpleNamespace(returncode=0, stdout="")
         raise AssertionError("unexpected command")
@@ -31,11 +33,12 @@ def test_apply_retention_deletes_old(monkeypatch):
 
 def test_apply_retention_no_delete(monkeypatch):
     client = BackupClient("http://url", "token")
-    monkeypatch.setenv("RCLONE_REMOTE", "drive:")
+    monkeypatch.setenv("RCLONE_REMOTE", "drive")
     deleted: list[str] = []
 
     def fake_run(cmd, capture_output=False, text=False, check=False):
         if cmd[:2] == ["rclone", "lsl"]:
+            assert cmd[2] == "drive:"
             return SimpleNamespace(
                 stdout=(
                     "100 2024-01-01 00:00:00 app_20240101.bak\n"
@@ -44,6 +47,7 @@ def test_apply_retention_no_delete(monkeypatch):
                 returncode=0,
             )
         elif cmd[:2] == ["rclone", "delete"]:
+            assert cmd[2].startswith("drive:")
             deleted.append(cmd[2])
             return SimpleNamespace(returncode=0, stdout="")
         raise AssertionError("unexpected command")


### PR DESCRIPTION
## Summary
- add a helper to normalize rclone remote names and use it when uploading or enforcing retention
- persist colon-suffixed remote identifiers when registering or updating apps via the API
- refresh tests to expect normalized remotes and verify generated commands include the trailing colon

## Testing
- pytest
- pytest tests/test_client_upload.py

------
https://chatgpt.com/codex/tasks/task_e_68cb1e8417188332b339b2dd657050a5