### PR TITLE
Handle manual rclone authorization sessions

### DIFF
--- a/orchestrator/app/static/js/remotes.js
+++ b/orchestrator/app/static/js/remotes.js
@@ -1,3 +1,5 @@
+let currentAuthSessionId = null;
+
 async function loadRemotes() {
   const resp = await fetch('/rclone/remotes');
   if (resp.status === 401) {
@@ -74,8 +76,8 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.href = '/login';
         return;
       }
-      const data = await resp.json();
-      if (data.url) {
+      const data = await resp.json().catch(() => ({}));
+      if (resp.ok && data.url) {
         const urlInput = document.getElementById('auth_url');
         const link = document.getElementById('auth_link');
         const container = document.getElementById('auth-url-container');
@@ -85,6 +87,14 @@ document.addEventListener('DOMContentLoaded', () => {
           link.textContent = data.url;
         }
         if (container) container.style.display = '';
+        currentAuthSessionId = data.session_id || null;
+        const codeInput = document.getElementById('auth_code');
+        if (codeInput) codeInput.value = '';
+      } else {
+        if (container) container.style.display = 'none';
+        currentAuthSessionId = null;
+        const message = data && data.error ? data.error : 'No se pudo iniciar la autorización';
+        alert(message);
       }
     });
   }
@@ -102,20 +112,30 @@ document.addEventListener('DOMContentLoaded', () => {
   if (finishBtn) {
     finishBtn.addEventListener('click', async () => {
       const name = document.getElementById('auth_remote').value;
-      const token = document.getElementById('auth_token').value;
-      if (!name || !token) return;
+      const codeInput = document.getElementById('auth_code');
+      const code = codeInput ? codeInput.value : '';
+      if (!name || !code) return;
+      if (!currentAuthSessionId) {
+        alert('Inicie la autorización antes de completarla.');
+        return;
+      }
       const resp = await fetch(`/rclone/remotes/${name}/authorize`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token })
+        body: JSON.stringify({ session_id: currentAuthSessionId, code })
       });
       if (resp.status === 401) {
         window.location.href = '/login';
         return;
       }
+      const data = await resp.json().catch(() => ({}));
       if (resp.ok) {
-        document.getElementById('auth_token').value = '';
+        if (codeInput) codeInput.value = '';
+        currentAuthSessionId = null;
         alert('Remote authorized');
+      } else {
+        const message = data && data.error ? data.error : 'No se pudo completar la autorización';
+        alert(message);
       }
     });
   }

--- a/orchestrator/app/templates/rclone_config.html
+++ b/orchestrator/app/templates/rclone_config.html
@@ -34,8 +34,8 @@
     <a id="auth_link" href="#" target="_blank" class="d-block"></a>
   </div>
   <div class="mb-3">
-    <label for="auth_token" class="form-label">Token</label>
-    <textarea id="auth_token" class="form-control" rows="3"></textarea>
+    <label for="auth_code" class="form-label">Código de verificación</label>
+    <textarea id="auth_code" class="form-control" rows="3"></textarea>
   </div>
   <button id="finish-auth" class="btn btn-primary">Finalizar autorización</button>
 </div>

--- a/orchestrator/services/rclone.py
+++ b/orchestrator/services/rclone.py
@@ -1,38 +1,203 @@
+import json
 import re
 import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import IO
 
 
-def authorize_drive() -> str:
-    """Run ``rclone authorize "drive"`` and return the authorization URL.
+@dataclass
+class AuthorizationSession:
+    """State for an in-flight ``rclone authorize`` invocation."""
 
-    The command normally prints a line containing the URL the user must open in
-    their browser. This helper captures the output, extracts the first URL and
-    terminates the process once found.
-    """
-    proc = subprocess.Popen(
-        ["rclone", "authorize", "drive"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    if proc.stdout is None:
-        proc.kill()
-        raise RuntimeError("failed to capture rclone output")
+    remote: str
+    process: subprocess.Popen[str]
+    stdout: IO[str]
+    stdin: IO[str]
 
-    url: str | None = None
-    try:
-        for line in proc.stdout:
-            match = re.search(r"https?://\S+", line)
-            if match:
-                url = match.group(0)
-                break
-    finally:
+
+_AUTH_SESSIONS: dict[str, AuthorizationSession] = {}
+_AUTH_LOCK = threading.Lock()
+_URL_TIMEOUT = 30.0
+_TOKEN_TIMEOUT = 60.0
+
+
+def _stop_process(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is None:
         proc.terminate()
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
-    if not url:
-        raise RuntimeError("authorization URL not found")
-    return url
+
+
+def _cleanup_session(session_id: str, terminate: bool = False) -> None:
+    session: AuthorizationSession | None
+    with _AUTH_LOCK:
+        session = _AUTH_SESSIONS.pop(session_id, None)
+    if not session:
+        return
+    proc = session.process
+    try:
+        if proc.poll() is None:
+            if terminate:
+                proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        for stream in (session.stdout, session.stdin):
+            try:
+                stream.close()
+            except Exception:
+                pass
+    finally:
+        if proc.poll() is None:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def _cleanup_sessions_for_remote(remote: str) -> None:
+    pending: list[str] = []
+    with _AUTH_LOCK:
+        for session_id, session in _AUTH_SESSIONS.items():
+            if session.remote == remote:
+                pending.append(session_id)
+    for session_id in pending:
+        _cleanup_session(session_id, terminate=True)
+
+
+def _wait_for_authorization_url(proc: subprocess.Popen[str]) -> str:
+    assert proc.stdout is not None
+    start = time.monotonic()
+    while True:
+        if _URL_TIMEOUT and time.monotonic() - start > _URL_TIMEOUT:
+            raise RuntimeError("timed out waiting for authorization URL")
+        line = proc.stdout.readline()
+        if not line:
+            if proc.poll() is not None:
+                break
+            time.sleep(0.1)
+            continue
+        match = re.search(r"https?://\S+", line)
+        if match:
+            return match.group(0)
+    raise RuntimeError("authorization URL not found")
+
+
+def get_authorization_session(session_id: str) -> AuthorizationSession | None:
+    """Return the cached session for *session_id* if available."""
+
+    with _AUTH_LOCK:
+        return _AUTH_SESSIONS.get(session_id)
+
+
+def authorize_drive(remote: str) -> tuple[str, str]:
+    """Run ``rclone authorize drive`` and return ``(session_id, url)``.
+
+    The command normally prints a line containing the URL the user must open in
+    their browser. This helper captures the output, extracts the first URL and
+    keeps the process alive so that the caller can later provide the
+    verification code and capture the resulting token JSON.
+    """
+    try:
+        proc = subprocess.Popen(
+            [
+                "rclone",
+                "authorize",
+                "drive",
+                "--auth-no-open-browser",
+                "--manual",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("rclone is not installed") from exc
+
+    if proc.stdout is None or proc.stdin is None:
+        _stop_process(proc)
+        raise RuntimeError("failed to capture rclone output")
+
+    try:
+        url = _wait_for_authorization_url(proc)
+    except Exception:
+        _stop_process(proc)
+        raise
+
+    session_id = uuid.uuid4().hex
+    _cleanup_sessions_for_remote(remote)
+    with _AUTH_LOCK:
+        _AUTH_SESSIONS[session_id] = AuthorizationSession(
+            remote=remote, process=proc, stdout=proc.stdout, stdin=proc.stdin
+        )
+    return session_id, url
+
+
+def _wait_for_token(session: AuthorizationSession) -> str:
+    proc = session.process
+    stdout = session.stdout
+    start = time.monotonic()
+    collecting = False
+    buffer = ""
+    while True:
+        if _TOKEN_TIMEOUT and time.monotonic() - start > _TOKEN_TIMEOUT:
+            raise RuntimeError("timed out waiting for authorization token")
+        line = stdout.readline()
+        if not line:
+            if proc.poll() is not None:
+                break
+            time.sleep(0.1)
+            continue
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not collecting and "{" not in stripped:
+            continue
+        collecting = True
+        buffer += line
+        candidate = buffer.strip()
+        try:
+            json.loads(candidate)
+            return candidate
+        except json.JSONDecodeError:
+            continue
+    raise RuntimeError("failed to read authorization token from rclone")
+
+
+def complete_drive_authorization(session_id: str, code: str) -> str:
+    """Submit *code* to the pending session and return the token JSON."""
+
+    with _AUTH_LOCK:
+        session = _AUTH_SESSIONS.get(session_id)
+    if not session:
+        raise RuntimeError("authorization session not found")
+
+    proc = session.process
+    if proc.poll() is not None:
+        _cleanup_session(session_id)
+        raise RuntimeError("authorization session is no longer active")
+
+    submission = f"{code.rstrip('\n')}\n"
+    try:
+        session.stdin.write(submission)
+        session.stdin.flush()
+    except Exception as exc:  # pragma: no cover - defensive
+        _cleanup_session(session_id, terminate=True)
+        raise RuntimeError("failed to submit verification code") from exc
+
+    try:
+        token = _wait_for_token(session)
+    except Exception:
+        _cleanup_session(session_id, terminate=True)
+        raise
+
+    _cleanup_session(session_id)
+    return token
 

--- a/tests/test_rclone_authorize.py
+++ b/tests/test_rclone_authorize.py
@@ -1,6 +1,9 @@
 import os
+import queue
 import sys
-import subprocess
+from types import SimpleNamespace
+
+import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
@@ -9,36 +12,165 @@ os.environ["APP_ADMIN_PASS"] = "secret"
 os.environ["APP_SECRET_KEY"] = "test-key"
 
 from orchestrator.app import create_app
+from orchestrator.services import rclone as rclone_service
 
 
-def test_authorize_returns_url(monkeypatch):
+class FakeStdout:
+    def __init__(self, proc: "FakeProcess") -> None:
+        self.proc = proc
+
+    def readline(self) -> str:
+        try:
+            return self.proc.stdout_queue.get(timeout=0.05)
+        except queue.Empty:
+            return ""
+
+    def close(self) -> None:  # pragma: no cover - nothing to clean
+        pass
+
+
+class FakeStdin:
+    def __init__(self, proc: "FakeProcess") -> None:
+        self.proc = proc
+        self.writes: list[str] = []
+
+    def write(self, data: str) -> int:
+        self.writes.append(data)
+        if data.endswith("\n") and not self.proc.json_sent:
+            self.proc.stdout_queue.put(self.proc.token_json + "\n")
+            self.proc.json_sent = True
+            self.proc.returncode = 0
+        return len(data)
+
+    def flush(self) -> None:  # pragma: no cover - nothing to flush
+        pass
+
+    def close(self) -> None:  # pragma: no cover - nothing to clean
+        pass
+
+
+class FakeProcess:
+    def __init__(self, url: str, token_json: str) -> None:
+        self.url = url
+        self.token_json = token_json
+        self.stdout_queue: "queue.Queue[str]" = queue.Queue()
+        self.stdout_queue.put(f"Visit {url}\n")
+        self.stdout = FakeStdout(self)
+        self.stdin = FakeStdin(self)
+        self.returncode: int | None = None
+        self.json_sent = False
+        self.command: list[str] | None = None
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def terminate(self) -> None:  # pragma: no cover - not triggered in tests
+        self.returncode = -15
+
+    def kill(self) -> None:  # pragma: no cover - not triggered in tests
+        self.returncode = -9
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions() -> None:
+    rclone_service._AUTH_SESSIONS.clear()
+    yield
+    rclone_service._AUTH_SESSIONS.clear()
+
+
+def login(client) -> None:
+    client.post("/login", data={"username": "admin", "password": "secret"})
+
+
+def test_authorize_returns_url_and_session(monkeypatch):
     monkeypatch.setattr("orchestrator.app.start_scheduler", lambda: None)
-    monkeypatch.setattr("orchestrator.app.authorize_drive", lambda: "http://auth")
+    fake_proc = FakeProcess("http://auth", "{\"token\": \"value\"}")
+
+    def fake_popen(cmd, **kwargs):
+        fake_proc.command = cmd
+        return fake_proc
+
+    monkeypatch.setattr(rclone_service.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        rclone_service.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="session123"),
+    )
     app = create_app()
     client = app.test_client()
-    client.post("/login", data={"username": "admin", "password": "secret"})
+    login(client)
     resp = client.get("/rclone/remotes/foo/authorize")
     assert resp.status_code == 200
-    assert resp.get_json() == {"url": "http://auth"}
+    assert resp.get_json() == {"url": "http://auth", "session_id": "session123"}
+    assert fake_proc.command == [
+        "rclone",
+        "authorize",
+        "drive",
+        "--auth-no-open-browser",
+        "--manual",
+    ]
+    session = rclone_service.get_authorization_session("session123")
+    assert session is not None
+    assert session.process is fake_proc
 
 
-def test_authorize_updates_config(monkeypatch):
+def test_authorize_flow_updates_remote(monkeypatch):
     monkeypatch.setattr("orchestrator.app.start_scheduler", lambda: None)
+    fake_proc = FakeProcess("http://auth", "{\"access_token\": \"abc\"}")
 
-    def fail():
-        raise AssertionError("authorize_drive should not be called")
+    def fake_popen(cmd, **kwargs):
+        fake_proc.command = cmd
+        return fake_proc
 
-    monkeypatch.setattr("orchestrator.app.authorize_drive", fail)
-    called: dict[str, list[str]] = {}
+    monkeypatch.setattr(rclone_service.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        rclone_service.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="session456"),
+    )
+    recorded: dict[str, object] = {}
 
-    def fake_run(cmd, check):
-        called["cmd"] = cmd
+    def fake_run(cmd, **kwargs):
+        recorded["cmd"] = cmd
+        recorded["kwargs"] = kwargs
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+        return Result()
+
+    monkeypatch.setattr("orchestrator.app.subprocess.run", fake_run)
     app = create_app()
     client = app.test_client()
-    client.post("/login", data={"username": "admin", "password": "secret"})
-    resp = client.post("/rclone/remotes/foo/authorize", json={"token": "tkn"})
+    login(client)
+
+    resp = client.get("/rclone/remotes/foo/authorize")
+    session_id = resp.get_json()["session_id"]
+
+    resp = client.post(
+        "/rclone/remotes/foo/authorize",
+        json={"session_id": session_id, "code": "the-code"},
+    )
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "ok"}
-    assert called["cmd"] == ["rclone", "config", "update", "foo", "token", "tkn"]
+    assert fake_proc.stdin.writes[-1] == "the-code\n"
+    assert recorded["cmd"] == [
+        "rclone",
+        "--config",
+        "/config/rclone/rclone.conf",
+        "config",
+        "update",
+        "foo",
+        "token",
+        "{\"access_token\": \"abc\"}",
+    ]
+    assert recorded["kwargs"]["check"] is True
+    assert recorded["kwargs"]["capture_output"] is True
+    assert recorded["kwargs"]["text"] is True
+    assert rclone_service.get_authorization_session(session_id) is None


### PR DESCRIPTION
## Summary
- maintain pending rclone authorize processes and expose a completion helper that yields the token JSON
- return authorization session identifiers from the API and consume them with the user-provided code to update the remote
- wire the UI to track the session identifier while the user authorizes and extend tests to cover the full flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb3497d2d4833297c77e91e42e29df