### PR TITLE
Revamp remote configuration UI and backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,18 @@ BACKUP_MAX_SIZE_MB=20480
 RCLONE_REMOTE=gdrive
 # Remote por defecto si la app no especifica uno propio
 # Cada app elige su carpeta destino; el orquestador guarda el folderId por app
+
+# Destinos disponibles para los remotes preconfigurados
+# Usa formato "Etiqueta|/ruta" y separá múltiples opciones con punto y coma
+RCLONE_LOCAL_DIRECTORIES=/backups/default
+RCLONE_SFTP_DIRECTORIES=
+RCLONE_SFTP_HOST=
+RCLONE_SFTP_PORT=22
+RCLONE_SFTP_USER=
+# Configurá al menos uno de los dos métodos de autenticación
+#RCLONE_SFTP_PASSWORD=
+#RCLONE_SFTP_KEY_FILE=/ruta/a/id_rsa
+
+# Opcionales para Google Drive
+#RCLONE_DRIVE_CLIENT_ID=
+#RCLONE_DRIVE_CLIENT_SECRET=

--- a/orchestrator/app/static/js/remotes.js
+++ b/orchestrator/app/static/js/remotes.js
@@ -1,55 +1,311 @@
-let currentAuthSessionId = null;
+const directoryCache = {};
+let driveValidation = { status: 'idle', token: '' };
 
 async function loadRemotes() {
-  const resp = await fetch('/rclone/remotes');
-  if (resp.status === 401) {
-    window.location.href = '/login';
+  try {
+    const resp = await fetch('/rclone/remotes');
+    if (resp.status === 401) {
+      window.location.href = '/login';
+      return;
+    }
+    const remotes = await resp.json();
+    const tbody = document.querySelector('#remotes-table tbody');
+    if (tbody) {
+      tbody.innerHTML = '';
+    }
+    const select = document.getElementById('rclone_remote');
+    if (select) {
+      select.innerHTML = '<option value=""></option>';
+    }
+    remotes.forEach((name) => {
+      if (tbody) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${name}</td>`;
+        tbody.appendChild(tr);
+      }
+      if (select) {
+        const opt = document.createElement('option');
+        opt.value = name;
+        opt.textContent = name;
+        select.appendChild(opt);
+      }
+    });
+  } catch (error) {
+    console.error('No se pudieron cargar los remotes configurados', error);
+  }
+}
+
+function showFeedback(message, type = 'info') {
+  const feedback = document.getElementById('remote-feedback');
+  if (!feedback) return;
+  const baseClass = 'alert mt-4';
+  if (!message) {
+    feedback.className = `${baseClass} d-none`;
+    feedback.textContent = '';
     return;
   }
-  const remotes = await resp.json();
-  const tbody = document.querySelector('#remotes-table tbody');
-  if (tbody) {
-    tbody.innerHTML = '';
+  feedback.className = `${baseClass} alert-${type}`;
+  feedback.textContent = message;
+}
+
+function updateDriveFeedback(message, variant = 'muted') {
+  const target = document.getElementById('drive-token-feedback');
+  if (!target) return;
+  target.classList.remove('text-success', 'text-danger', 'text-warning');
+  if (!message) {
+    target.textContent = '';
+    target.classList.add('text-muted');
+    return;
   }
-  const select = document.getElementById('rclone_remote');
-  if (select) {
-    select.innerHTML = '<option value=""></option>';
+  target.textContent = message;
+  target.classList.remove('text-muted');
+  if (variant === 'success') {
+    target.classList.add('text-success');
+  } else if (variant === 'warning') {
+    target.classList.add('text-warning');
+  } else if (variant === 'danger') {
+    target.classList.add('text-danger');
+  } else {
+    target.classList.add('text-muted');
   }
-  const authSelect = document.getElementById('auth_remote');
-  if (authSelect) {
-    authSelect.innerHTML = '<option value=""></option>';
+}
+
+function resetPanels() {
+  document.querySelectorAll('[data-remote-panel]').forEach((panel) => {
+    panel.classList.add('d-none');
+  });
+}
+
+async function fetchDirectoryOptions(type) {
+  if (directoryCache[type]) {
+    return directoryCache[type];
   }
-  remotes.forEach(name => {
-    if (tbody) {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${name}</td>`;
-      tbody.appendChild(tr);
+  const resp = await fetch(`/rclone/remotes/options/${type}`);
+  if (resp.status === 401) {
+    window.location.href = '/login';
+    return {};
+  }
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok) {
+    const message = data && data.error ? data.error : 'No se pudo cargar la configuración';
+    throw new Error(message);
+  }
+  directoryCache[type] = data;
+  return data;
+}
+
+function populateDirectorySelect(select, directories, emptyMessageId) {
+  if (!select) return;
+  const emptyMessage = emptyMessageId ? document.getElementById(emptyMessageId) : null;
+  select.innerHTML = '';
+  if (!directories || directories.length === 0) {
+    select.disabled = true;
+    if (emptyMessage) {
+      emptyMessage.classList.remove('d-none');
     }
-    if (select) {
-      const opt = document.createElement('option');
-      opt.value = name;
-      opt.textContent = name;
-      select.appendChild(opt);
+    return;
+  }
+  if (emptyMessage) {
+    emptyMessage.classList.add('d-none');
+  }
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Seleccione…';
+  select.appendChild(placeholder);
+  directories.forEach((entry) => {
+    const option = document.createElement('option');
+    option.value = entry.path;
+    if (entry.label && entry.label !== entry.path) {
+      option.textContent = `${entry.label} — ${entry.path}`;
+    } else {
+      option.textContent = entry.path;
     }
-    if (authSelect) {
-      const opt2 = document.createElement('option');
-      opt2.value = name;
-      opt2.textContent = name;
-      authSelect.appendChild(opt2);
+    select.appendChild(option);
+  });
+  select.disabled = false;
+}
+
+async function showPanelForType(type) {
+  resetPanels();
+  updateDriveFeedback('', 'muted');
+  if (!type) {
+    return;
+  }
+  const panel = document.querySelector(`[data-remote-panel="${type}"]`);
+  if (!panel) {
+    return;
+  }
+  panel.classList.remove('d-none');
+  if (type === 'local') {
+    const select = document.getElementById('local_path');
+    try {
+      const data = await fetchDirectoryOptions('local');
+      populateDirectorySelect(select, data.directories || [], 'local-empty');
+    } catch (err) {
+      if (select) {
+        select.innerHTML = '<option value="">No se pudieron cargar las carpetas</option>';
+        select.disabled = true;
+      }
+      showFeedback(err.message, 'danger');
+    }
+  } else if (type === 'sftp') {
+    const select = document.getElementById('sftp_path');
+    const details = document.getElementById('sftp-details');
+    try {
+      const data = await fetchDirectoryOptions('sftp');
+      populateDirectorySelect(select, data.directories || [], 'sftp-empty');
+      if (details) {
+        const host = data.host;
+        const port = data.port ? `:${data.port}` : '';
+        if (host) {
+          details.textContent = `Conexión configurada: ${host}${port}`;
+          details.classList.remove('d-none');
+        } else {
+          details.textContent = '';
+          details.classList.add('d-none');
+        }
+      }
+    } catch (err) {
+      if (select) {
+        select.innerHTML = '<option value="">No se pudieron cargar las carpetas</option>';
+        select.disabled = true;
+      }
+      if (details) {
+        details.textContent = '';
+        details.classList.add('d-none');
+      }
+      showFeedback(err.message, 'danger');
+    }
+  } else if (type === 'drive') {
+    driveValidation = { status: 'idle', token: '' };
+    updateDriveFeedback('Recordá probar el token antes de guardar.', 'warning');
+  } else if (type === 'onedrive') {
+    showFeedback('La integración con OneDrive está en construcción.', 'info');
+  }
+}
+
+function initDriveValidation() {
+  const tokenInput = document.getElementById('drive_token');
+  const testButton = document.getElementById('drive-test-token');
+  if (!tokenInput || !testButton) {
+    return;
+  }
+  tokenInput.addEventListener('input', () => {
+    if (driveValidation.status === 'success' && driveValidation.token !== tokenInput.value.trim()) {
+      updateDriveFeedback('El token cambió, probalo nuevamente antes de guardar.', 'warning');
+      driveValidation = { status: 'dirty', token: '' };
+    } else if (!tokenInput.value.trim()) {
+      updateDriveFeedback('', 'muted');
+      driveValidation = { status: 'idle', token: '' };
+    }
+  });
+  testButton.addEventListener('click', async () => {
+    const token = tokenInput.value.trim();
+    if (!token) {
+      updateDriveFeedback('Pegá el token de Google Drive antes de probarlo.', 'danger');
+      return;
+    }
+    testButton.disabled = true;
+    updateDriveFeedback('Probando token…', 'warning');
+    try {
+      const resp = await fetch('/rclone/remotes/drive/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token })
+      });
+      if (resp.status === 401) {
+        window.location.href = '/login';
+        return;
+      }
+      const data = await resp.json().catch(() => ({}));
+      if (resp.ok) {
+        updateDriveFeedback('Token válido. Ya podés guardar el remote.', 'success');
+        driveValidation = { status: 'success', token };
+      } else {
+        const message = data && data.error ? data.error : 'No se pudo validar el token';
+        updateDriveFeedback(message, 'danger');
+        driveValidation = { status: 'error', token: '' };
+      }
+    } catch (err) {
+      updateDriveFeedback('Error al comunicarse con el servidor para validar el token.', 'danger');
+      driveValidation = { status: 'error', token: '' };
+    } finally {
+      testButton.disabled = false;
     }
   });
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  loadRemotes();
+function initRemoteForm() {
   const form = document.getElementById('remote-form');
-  if (form) {
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const payload = {
-        name: document.getElementById('remote_name').value,
-        type: document.getElementById('remote_type').value,
-      };
+  if (!form) {
+    return;
+  }
+  const typeSelect = document.getElementById('remote_type');
+  if (typeSelect) {
+    showPanelForType(typeSelect.value);
+    typeSelect.addEventListener('change', (event) => {
+      const selected = event.target.value;
+      showFeedback('', 'info');
+      showPanelForType(selected);
+    });
+  }
+  initDriveValidation();
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    showFeedback('', 'info');
+    const nameInput = document.getElementById('remote_name');
+    const type = typeSelect ? typeSelect.value : '';
+    const name = nameInput ? nameInput.value.trim() : '';
+    if (!name) {
+      showFeedback('Completá un nombre para el remote.', 'danger');
+      return;
+    }
+    if (!type) {
+      showFeedback('Elegí el tipo de remote que querés configurar.', 'danger');
+      return;
+    }
+
+    const payload = { name, type, settings: {} };
+    if (type === 'local') {
+      const select = document.getElementById('local_path');
+      const value = select ? select.value : '';
+      if (!value) {
+        showFeedback('Seleccioná la carpeta local donde guardar los respaldos.', 'danger');
+        return;
+      }
+      payload.settings.path = value;
+    } else if (type === 'sftp') {
+      const select = document.getElementById('sftp_path');
+      const value = select ? select.value : '';
+      if (!value) {
+        showFeedback('Elegí la carpeta del servidor SFTP para este remote.', 'danger');
+        return;
+      }
+      payload.settings.path = value;
+    } else if (type === 'drive') {
+      const token = document.getElementById('drive_token')?.value.trim() || '';
+      if (!token) {
+        showFeedback('Pegá el token de Google Drive antes de guardar.', 'danger');
+        return;
+      }
+      if (driveValidation.status === 'success' && driveValidation.token !== token) {
+        driveValidation = { status: 'dirty', token: '' };
+      }
+      payload.settings.token = token;
+      if (driveValidation.status !== 'success') {
+        showFeedback('Probá el token de Google Drive antes de guardarlo.', 'warning');
+        return;
+      }
+    } else if (type === 'onedrive') {
+      showFeedback('OneDrive todavía no está disponible.', 'warning');
+      return;
+    }
+
+    const submitBtn = form.querySelector('button[type="submit"]');
+    if (submitBtn) {
+      submitBtn.disabled = true;
+    }
+    try {
       const resp = await fetch('/rclone/remotes', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -59,89 +315,31 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.href = '/login';
         return;
       }
+      const data = await resp.json().catch(() => ({}));
       if (resp.ok) {
         form.reset();
+        resetPanels();
+        driveValidation = { status: 'idle', token: '' };
+        updateDriveFeedback('', 'muted');
+        delete directoryCache.local;
+        delete directoryCache.sftp;
+        showFeedback('Remote guardado correctamente.', 'success');
         loadRemotes();
-      }
-    });
-  }
-
-  const startBtn = document.getElementById('start-auth');
-  if (startBtn) {
-    startBtn.addEventListener('click', async () => {
-      const name = document.getElementById('auth_remote').value;
-      if (!name) return;
-      const urlInput = document.getElementById('auth_url');
-      const link = document.getElementById('auth_link');
-      const container = document.getElementById('auth-url-container');
-      const codeInput = document.getElementById('auth_code');
-      const resp = await fetch(`/rclone/remotes/${name}/authorize`);
-      if (resp.status === 401) {
-        window.location.href = '/login';
-        return;
-      }
-      const data = await resp.json().catch(() => ({}));
-      if (resp.ok && data.url) {
-        if (urlInput) urlInput.value = data.url;
-        if (link) {
-          link.href = data.url;
-          link.textContent = data.url;
-        }
-        if (container) container.style.display = '';
-        currentAuthSessionId = data.session_id || null;
-        if (codeInput) codeInput.value = '';
       } else {
-        if (container) container.style.display = 'none';
-        if (urlInput) urlInput.value = '';
-        if (link) {
-          link.removeAttribute('href');
-          link.textContent = '';
-        }
-        currentAuthSessionId = null;
-        const message = data && data.error ? data.error : 'No se pudo iniciar la autorización';
-        alert(message);
+        const message = data && data.error ? data.error : 'No se pudo crear el remote';
+        showFeedback(message, 'danger');
       }
-    });
-  }
+    } catch (err) {
+      showFeedback('Ocurrió un error al comunicarse con el servidor.', 'danger');
+    } finally {
+      if (submitBtn) {
+        submitBtn.disabled = false;
+      }
+    }
+  });
+}
 
-  const copyBtn = document.getElementById('copy-auth-url');
-  if (copyBtn) {
-    copyBtn.addEventListener('click', () => {
-      const input = document.getElementById('auth_url');
-      if (!input) return;
-      navigator.clipboard.writeText(input.value);
-    });
-  }
-
-  const finishBtn = document.getElementById('finish-auth');
-  if (finishBtn) {
-    finishBtn.addEventListener('click', async () => {
-      const name = document.getElementById('auth_remote').value;
-      const codeInput = document.getElementById('auth_code');
-      const code = codeInput ? codeInput.value : '';
-      if (!name || !code) return;
-      if (!currentAuthSessionId) {
-        alert('Inicie la autorización antes de completarla.');
-        return;
-      }
-      const resp = await fetch(`/rclone/remotes/${name}/authorize`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ session_id: currentAuthSessionId, code })
-      });
-      if (resp.status === 401) {
-        window.location.href = '/login';
-        return;
-      }
-      const data = await resp.json().catch(() => ({}));
-      if (resp.ok) {
-        if (codeInput) codeInput.value = '';
-        currentAuthSessionId = null;
-        alert('Remote authorized');
-      } else {
-        const message = data && data.error ? data.error : 'No se pudo completar la autorización';
-        alert(message);
-      }
-    });
-  }
+document.addEventListener('DOMContentLoaded', () => {
+  loadRemotes();
+  initRemoteForm();
 });

--- a/orchestrator/app/templates/rclone_config.html
+++ b/orchestrator/app/templates/rclone_config.html
@@ -2,41 +2,80 @@
 
 {% block content %}
 <div class="container py-4">
-  <h1 class="mb-4">Configurar Rclone</h1>
-  <form id="remote-form">
-    <div class="mb-3">
-      <label for="remote_name" class="form-label">Nombre</label>
-      <input type="text" class="form-control" id="remote_name" required>
+  <h1 class="mb-4">Configurar remote de Rclone</h1>
+  <form id="remote-form" class="mt-3" novalidate>
+    <div class="row g-3">
+      <div class="col-md-6">
+        <label for="remote_name" class="form-label">Nombre</label>
+        <input type="text" class="form-control" id="remote_name" required placeholder="Ej: gdrive_respaldos">
+      </div>
+      <div class="col-md-6">
+        <label for="remote_type" class="form-label">Tipo</label>
+        <select class="form-select" id="remote_type" required>
+          <option value="">Seleccione…</option>
+          <option value="drive">Google Drive</option>
+          <option value="onedrive">OneDrive</option>
+          <option value="sftp">SFTP</option>
+          <option value="local">Local</option>
+        </select>
+      </div>
     </div>
-    <div class="mb-3">
-      <label for="remote_type" class="form-label">Tipo</label>
-      <select class="form-select" id="remote_type" required>
-        <option value="">Seleccione...</option>
-        <option value="drive">drive (Google Drive)</option>
-        <option value="onedrive">onedrive</option>
-        <option value="sftp">sftp</option>
-        <option value="local">local</option>
-      </select>
+
+    <div id="remote-feedback" class="alert mt-4 d-none" role="alert"></div>
+
+    <div class="mt-4" id="remote-type-panels">
+      <div class="remote-panel d-none" data-remote-panel="local">
+        <h2 class="h5">Destino local</h2>
+        <p class="text-muted">Seleccioná una carpeta preconfigurada del servidor donde se guardarán los respaldos.</p>
+        <div class="mb-3">
+          <label for="local_path" class="form-label">Carpeta disponible</label>
+          <select class="form-select" id="local_path"></select>
+        </div>
+        <div id="local-empty" class="alert alert-warning d-none" role="alert">
+          No hay carpetas locales configuradas. Agregalas en la configuración del contenedor.
+        </div>
+      </div>
+
+      <div class="remote-panel d-none" data-remote-panel="sftp">
+        <h2 class="h5">Servidor SFTP</h2>
+        <p class="text-muted">Elegí la carpeta remota a la que el orquestador tiene acceso mediante SFTP.</p>
+        <div class="mb-3">
+          <label for="sftp_path" class="form-label">Carpeta remota</label>
+          <select class="form-select" id="sftp_path"></select>
+        </div>
+        <div id="sftp-details" class="text-muted small"></div>
+        <div id="sftp-empty" class="alert alert-warning d-none" role="alert">
+          No hay carpetas SFTP disponibles. Revisá la configuración del servidor.
+        </div>
+      </div>
+
+      <div class="remote-panel d-none" data-remote-panel="drive">
+        <h2 class="h5">Google Drive</h2>
+        <p>Segu&iacute; estos pasos para obtener el token manual:</p>
+        <ol>
+          <li>Abrí el asistente de rclone para Google Drive desde <a id="drive-doc-link" href="https://rclone.org/drive/" target="_blank" rel="noopener">la documentación oficial</a>.</li>
+          <li>Generá un token OAuth siguiendo las instrucciones de rclone.</li>
+          <li>Pegá el JSON del token en el campo siguiente y probá la conexión.</li>
+        </ol>
+        <div class="mb-3">
+          <label for="drive_token" class="form-label">Token de acceso</label>
+          <textarea id="drive_token" class="form-control" rows="4" placeholder='{"access_token": "..."}'></textarea>
+        </div>
+        <button type="button" class="btn btn-outline-secondary" id="drive-test-token">Probar token</button>
+        <div id="drive-token-feedback" class="form-text mt-2"></div>
+      </div>
+
+      <div class="remote-panel d-none" data-remote-panel="onedrive">
+        <h2 class="h5">OneDrive</h2>
+        <div class="alert alert-info" role="alert">
+          Integraci&oacute;n en construcci&oacute;n. Pronto vas a poder conectar OneDrive desde aquí.
+        </div>
+      </div>
     </div>
-    <button type="submit" class="btn btn-primary">Guardar</button>
+
+    <div class="mt-4">
+      <button type="submit" class="btn btn-primary">Guardar remote</button>
+    </div>
   </form>
-  <h2 class="mt-5">Autorizar Remote</h2>
-  <div class="mb-3">
-    <label for="auth_remote" class="form-label">Remote</label>
-    <select class="form-select" id="auth_remote"></select>
-  </div>
-  <button id="start-auth" class="btn btn-secondary mb-3">Iniciar autorización</button>
-  <div id="auth-url-container" class="mb-3" style="display:none;">
-    <div class="input-group mb-2">
-      <input id="auth_url" type="text" class="form-control" readonly>
-      <button class="btn btn-outline-secondary" type="button" id="copy-auth-url">Copiar</button>
-    </div>
-    <a id="auth_link" href="#" target="_blank" class="d-block"></a>
-  </div>
-  <div class="mb-3">
-    <label for="auth_code" class="form-label">Código de verificación</label>
-    <textarea id="auth_code" class="form-control" rows="3"></textarea>
-  </div>
-  <button id="finish-auth" class="btn btn-primary">Finalizar autorización</button>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add typed remote configuration endpoints, Drive token validation and env-driven local/SFTP directory handling on the backend
- redesign the remote setup page and scripts to show type-specific fields, enforce Drive token testing and surface configuration options
- extend environment samples and replace the old authorization tests with coverage for the new flows (Drive validation, local and SFTP remotes)

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc4eb2ef7c83329ddbaaf32e56990e