### PR TITLE
feat: require SFTP folder selection before remote creation

### DIFF
--- a/docs/ui_usage.md
+++ b/docs/ui_usage.md
@@ -43,7 +43,7 @@ La interfaz permite crear nuevos remotes sin abandonar el navegador.
 - Ingresá a **Rclone → Remotes** para ver el listado actual y el formulario de alta.
 - Completá **Nombre** y elegí el **Tipo** de backend (`drive`, `onedrive`, `sftp` o `local`). El formulario mostrará los campos necesarios según la opción seleccionada:
   - Para `local`, seleccioná una carpeta habilitada previamente en `RCLONE_LOCAL_DIRECTORIES`.
-  - Para `sftp`, ingresá host, puerto (opcional), usuario y contraseña. El orquestador valida el acceso creando una carpeta con el nombre del remote en el servidor remoto.
+- Para `sftp`, ingresá host, puerto (opcional), usuario y contraseña. Probá la conexión para listar las carpetas disponibles en el servidor y elegí dónde crear la carpeta del remote.
   - Para `drive`, pegá el token OAuth generado con rclone y utilizá el botón **Probar token** antes de guardar.
 - Al guardar, la UI invoca internamente `rclone config create` y actualiza el listado de remotes disponibles.
 

--- a/orchestrator/app/static/js/remotes.js
+++ b/orchestrator/app/static/js/remotes.js
@@ -1,5 +1,254 @@
 const directoryCache = {};
 let driveValidation = { status: 'idle', token: '' };
+const sftpState = {
+  credentials: null,
+  currentPath: '/',
+  parentPath: '/',
+};
+
+function normalizeSftpPath(path) {
+  if (!path) return '/';
+  let value = path.trim();
+  if (!value || value === '.' || value === './') {
+    return '/';
+  }
+  value = value.replace(/\\/g, '/');
+  if (!value.startsWith('/')) {
+    value = `/${value}`;
+  }
+  value = value.replace(/\/+/g, '/');
+  if (value.length > 1 && value.endsWith('/')) {
+    value = value.slice(0, -1);
+  }
+  return value || '/';
+}
+
+function updateSftpStatus(message, variant = 'muted') {
+  const target = document.getElementById('sftp-browser-feedback');
+  if (!target) return;
+  target.classList.remove('text-danger', 'text-success', 'text-muted');
+  if (!message) {
+    target.textContent = '';
+    target.classList.add('text-muted');
+    return;
+  }
+  target.textContent = message;
+  if (variant === 'danger') {
+    target.classList.add('text-danger');
+  } else if (variant === 'success') {
+    target.classList.add('text-success');
+  } else {
+    target.classList.add('text-muted');
+  }
+}
+
+function updateSftpSelectedPath(path) {
+  const input = document.getElementById('sftp_base_path');
+  const summary = document.getElementById('sftp-selected-path');
+  if (!input || !summary) return;
+  summary.classList.remove('text-success', 'text-muted', 'text-danger');
+  if (!path) {
+    input.value = '';
+    summary.textContent = 'Todavía no elegiste la carpeta donde se crearán los respaldos.';
+    summary.classList.add('text-muted');
+    return;
+  }
+  const normalized = normalizeSftpPath(path);
+  input.value = normalized;
+  summary.textContent = `Se va a crear una carpeta con el nombre del remote dentro de ${normalized}.`;
+  summary.classList.add('text-success');
+}
+
+function resetSftpBrowser(clearSelection = true) {
+  sftpState.credentials = null;
+  sftpState.currentPath = '/';
+  sftpState.parentPath = '/';
+  const panel = document.getElementById('sftp-browser-panel');
+  if (panel) {
+    panel.classList.add('d-none');
+  }
+  const list = document.getElementById('sftp-directory-list');
+  if (list) {
+    list.innerHTML = '';
+  }
+  const emptyAlert = document.getElementById('sftp-empty');
+  if (emptyAlert) {
+    emptyAlert.classList.add('d-none');
+  }
+  const currentPathLabel = document.getElementById('sftp-current-path');
+  if (currentPathLabel) {
+    currentPathLabel.textContent = '/';
+  }
+  const upButton = document.getElementById('sftp-browser-up');
+  if (upButton) {
+    upButton.disabled = true;
+  }
+  updateSftpStatus('Completá las credenciales y listá las carpetas disponibles.', 'muted');
+  if (clearSelection) {
+    updateSftpSelectedPath('');
+  }
+}
+
+async function fetchSftpDirectories(path) {
+  if (!sftpState.credentials) {
+    return null;
+  }
+  const payload = { ...sftpState.credentials, path };
+  const resp = await fetch('/rclone/remotes/sftp/browse', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (resp.status === 401) {
+    window.location.href = '/login';
+    return null;
+  }
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok) {
+    const message = data && data.error ? data.error : 'No se pudieron listar las carpetas del servidor SFTP.';
+    updateSftpStatus(message, 'danger');
+    return null;
+  }
+  return data;
+}
+
+function renderSftpBrowser(data) {
+  const panel = document.getElementById('sftp-browser-panel');
+  const list = document.getElementById('sftp-directory-list');
+  const emptyAlert = document.getElementById('sftp-empty');
+  const currentPathLabel = document.getElementById('sftp-current-path');
+  const upButton = document.getElementById('sftp-browser-up');
+  if (!panel || !list || !currentPathLabel) {
+    return;
+  }
+  panel.classList.remove('d-none');
+  list.innerHTML = '';
+  const directories = Array.isArray(data.directories) ? data.directories : [];
+  sftpState.currentPath = normalizeSftpPath(data.current_path);
+  sftpState.parentPath = normalizeSftpPath(data.parent_path);
+  currentPathLabel.textContent = sftpState.currentPath;
+  if (upButton) {
+    upButton.disabled = sftpState.currentPath === '/' || sftpState.parentPath === sftpState.currentPath;
+  }
+  if (directories.length === 0) {
+    if (emptyAlert) {
+      emptyAlert.classList.remove('d-none');
+    }
+    return;
+  }
+  if (emptyAlert) {
+    emptyAlert.classList.add('d-none');
+  }
+  directories
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }))
+    .forEach((entry) => {
+      if (!entry || !entry.name || !entry.path) {
+        return;
+      }
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'list-group-item list-group-item-action';
+      item.textContent = entry.name;
+      item.dataset.path = entry.path;
+      list.appendChild(item);
+    });
+}
+
+async function openSftpPath(path) {
+  if (!sftpState.credentials) {
+    updateSftpStatus('Probá la conexión antes de navegar las carpetas.', 'danger');
+    return;
+  }
+  updateSftpStatus('Cargando carpetas…', 'muted');
+  const data = await fetchSftpDirectories(path);
+  if (data) {
+    renderSftpBrowser(data);
+    updateSftpStatus('Seleccioná la carpeta donde querés guardar los respaldos.', 'muted');
+  }
+}
+
+function initSftpBrowser() {
+  resetSftpBrowser(true);
+  const browseButton = document.getElementById('sftp-browse');
+  const list = document.getElementById('sftp-directory-list');
+  const upButton = document.getElementById('sftp-browser-up');
+  const useButton = document.getElementById('sftp-use-current');
+  if (!browseButton || !list || !upButton || !useButton) {
+    return;
+  }
+
+  browseButton.addEventListener('click', async () => {
+    const host = document.getElementById('sftp_host')?.value.trim() || '';
+    const portValue = document.getElementById('sftp_port')?.value.trim() || '';
+    const username = document.getElementById('sftp_username')?.value.trim() || '';
+    const password = document.getElementById('sftp_password')?.value || '';
+    if (!host || !username || !password) {
+      updateSftpStatus('Completá host, usuario y contraseña antes de listar las carpetas.', 'danger');
+      return;
+    }
+    if (portValue && !/^\d+$/.test(portValue)) {
+      updateSftpStatus('El puerto SFTP debe ser un número válido.', 'danger');
+      return;
+    }
+    sftpState.credentials = { host, username, password };
+    if (portValue) {
+      sftpState.credentials.port = portValue;
+    }
+    updateSftpSelectedPath('');
+    updateSftpStatus('Conectando con el servidor SFTP…', 'muted');
+    browseButton.disabled = true;
+    try {
+      const data = await fetchSftpDirectories('/');
+      if (data) {
+        renderSftpBrowser(data);
+        updateSftpStatus('Seleccioná la carpeta donde querés guardar los respaldos.', 'muted');
+      }
+    } catch (err) {
+      updateSftpStatus('No se pudieron listar las carpetas del servidor SFTP.', 'danger');
+    } finally {
+      browseButton.disabled = false;
+    }
+  });
+
+  list.addEventListener('click', async (event) => {
+    const target = event.target instanceof Element ? event.target.closest('button[data-path]') : null;
+    if (!target) {
+      return;
+    }
+    const { path } = target.dataset;
+    if (!path) {
+      return;
+    }
+    await openSftpPath(path);
+  });
+
+  upButton.addEventListener('click', async () => {
+    if (upButton.disabled) {
+      return;
+    }
+    await openSftpPath(sftpState.parentPath);
+  });
+
+  useButton.addEventListener('click', () => {
+    if (!sftpState.credentials) {
+      updateSftpStatus('Probá la conexión antes de elegir una carpeta.', 'danger');
+      return;
+    }
+    updateSftpSelectedPath(sftpState.currentPath);
+    updateSftpStatus('Carpeta seleccionada. Guardá el formulario para crear el remote.', 'success');
+  });
+
+  ['sftp_host', 'sftp_port', 'sftp_username', 'sftp_password'].forEach((id) => {
+    const field = document.getElementById(id);
+    if (!field) {
+      return;
+    }
+    field.addEventListener('input', () => {
+      resetSftpBrowser(true);
+    });
+  });
+}
 
 function getDriveMode() {
   const selected = document.querySelector('input[name="drive_mode"]:checked');
@@ -163,6 +412,9 @@ async function showPanelForType(type) {
   if (!type) {
     return;
   }
+  if (type !== 'sftp') {
+    resetSftpBrowser(true);
+  }
   const panel = document.querySelector(`[data-remote-panel="${type}"]`);
   if (!panel) {
     return;
@@ -182,6 +434,8 @@ async function showPanelForType(type) {
     }
   } else if (type === 'drive') {
     updateDriveModeUI();
+  } else if (type === 'sftp') {
+    resetSftpBrowser(false);
   } else if (type === 'onedrive') {
     showFeedback('La integración con OneDrive está en construcción.', 'info');
   }
@@ -276,6 +530,7 @@ function initRemoteForm() {
   if (!form) {
     return;
   }
+  initSftpBrowser();
   const typeSelect = document.getElementById('remote_type');
   if (typeSelect) {
     showPanelForType(typeSelect.value);
@@ -346,8 +601,14 @@ function initRemoteForm() {
       if (portValue) {
         payload.settings.port = portValue;
       }
-    } else if (type === 'drive') {
-      const mode = getDriveMode();
+      const basePath = document.getElementById('sftp_base_path')?.value.trim() || '';
+      if (!basePath) {
+        showFeedback('Seleccioná la carpeta del servidor SFTP donde se crearán los respaldos.', 'danger');
+        return;
+      }
+      payload.settings.base_path = basePath;
+  } else if (type === 'drive') {
+    const mode = getDriveMode();
       payload.settings.mode = mode;
       if (mode === 'shared') {
         const emailInput = document.getElementById('drive_email');
@@ -415,6 +676,7 @@ function initRemoteForm() {
         driveValidation = { status: 'idle', token: '' };
         updateDriveFeedback('', 'muted');
         delete directoryCache.local;
+        resetSftpBrowser(true);
         showFeedback('Remote guardado correctamente.', 'success');
         loadRemotes();
       } else {

--- a/orchestrator/app/templates/partials/remote_form.html
+++ b/orchestrator/app/templates/partials/remote_form.html
@@ -33,7 +33,7 @@
 
     <div class="remote-panel d-none" data-remote-panel="sftp">
       <h2 class="h5">Servidor SFTP</h2>
-      <p class="text-muted">Ingresá los datos de conexión. Vamos a probar el acceso y crear una carpeta con el nombre del remote para guardar los respaldos.</p>
+      <p class="text-muted">Ingresá los datos de conexión. Vamos a listar las carpetas disponibles y crear ahí una carpeta con el nombre del remote para guardar los respaldos.</p>
       <div class="row g-3">
         <div class="col-md-6">
           <label for="sftp_host" class="form-label">Host</label>
@@ -53,7 +53,29 @@
         </div>
       </div>
       <div class="form-text mt-2">
-        Si dejás el puerto vacío se usará el valor por defecto (22). La carpeta <code>&lt;nombre del remote&gt;</code> se creará automáticamente en el servidor remoto.
+        Si dejás el puerto vacío se usará el valor por defecto (22).
+      </div>
+      <div class="mt-3">
+        <button type="button" class="btn btn-outline-secondary" id="sftp-browse">Probar conexión y listar carpetas</button>
+        <div id="sftp-browser-feedback" class="form-text mt-2 text-muted"></div>
+      </div>
+      <div id="sftp-browser-panel" class="border rounded p-3 mt-3 d-none">
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+          <div><span class="fw-semibold">Carpeta actual:</span> <span id="sftp-current-path">/</span></div>
+          <div class="d-flex gap-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="sftp-browser-up" disabled>Subir un nivel</button>
+            <button type="button" class="btn btn-sm btn-success" id="sftp-use-current">Usar esta carpeta</button>
+          </div>
+        </div>
+        <p class="form-text mt-2 mb-0">Hacé clic en una carpeta para ver su contenido.</p>
+        <ul class="list-group mt-3" id="sftp-directory-list"></ul>
+        <div id="sftp-empty" class="alert alert-warning mt-3 d-none" role="alert">
+          No encontramos subcarpetas en esta ubicación. Podés usarla igual para guardar los respaldos.
+        </div>
+      </div>
+      <input type="hidden" id="sftp_base_path" value="">
+      <div id="sftp-selected-path" class="form-text mt-2 text-muted">
+        Todavía no elegiste la carpeta donde se crearán los respaldos.
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add SFTP helpers plus a /rclone/remotes/sftp/browse endpoint to list directories and translate common errors
- require choosing a base path when creating SFTP remotes and create the remote inside the selected folder
- update the UI, documentation and tests to cover the new SFTP selection flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8b864b4483329dbdee459676174a