### PR TITLE
Unify remote configuration and remotes listing UI

### DIFF
--- a/orchestrator/app/templates/partials/remotes_table.html
+++ b/orchestrator/app/templates/partials/remotes_table.html
@@ -1,0 +1,13 @@
+<div class="table-responsive">
+  <table class="table table-striped align-middle" id="remotes-table">
+    <thead>
+      <tr>
+        <th scope="col">Nombre</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</div>
+<div class="alert alert-info mt-3 d-none" id="remotes-empty" role="alert">
+  Todavía no hay remotes configurados. Creá uno para comenzar.
+</div>

--- a/orchestrator/app/templates/rclone_config.html
+++ b/orchestrator/app/templates/rclone_config.html
@@ -136,5 +136,11 @@
     </div>
   </form>
 
+  <div class="mt-5">
+    <h2 class="h4">Remotes configurados</h2>
+    <p class="text-muted">Consultá los remotes disponibles sin salir de esta página.</p>
+    {% include 'partials/remotes_table.html' %}
+  </div>
+
 </div>
 {% endblock %}

--- a/orchestrator/app/templates/remotes.html
+++ b/orchestrator/app/templates/remotes.html
@@ -2,35 +2,13 @@
 
 {% block content %}
 <div class="container py-4">
-  <div class="row g-4">
-    <div class="col-12 col-lg-6">
-      <h1 class="mb-3">Rclone Remotes</h1>
-      <p class="text-muted">Visualizá y administrá los remotes configurados en tu instancia de rclone.</p>
-      <div class="table-responsive">
-        <table class="table table-striped align-middle" id="remotes-table">
-          <thead>
-            <tr>
-              <th scope="col">Nombre</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
-      <div class="alert alert-info mt-3 d-none" id="remotes-empty" role="alert">
-        Todavía no hay remotes configurados. Creá uno con el formulario de la derecha.
-      </div>
-    </div>
-    <div class="col-12 col-lg-6">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h2 class="h5">Crear un nuevo remote</h2>
-          <p class="text-muted">Completá el formulario para crear un remote mediante <code>rclone config create</code> sin salir de la UI.</p>
-          <div class="mt-3">
-            {% include 'partials/remote_form.html' %}
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  <h1 class="mb-3">Rclone Remotes</h1>
+  <p class="text-muted">
+    Visualizá y administrá los remotes configurados en tu instancia de rclone.
+  </p>
+  <p class="text-muted small">
+    Para crear un nuevo remote, usá la opción <strong>Configurar</strong> del menú Rclone.
+  </p>
+  {% include 'partials/remotes_table.html' %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the remote creation form from the remotes listing page
- add a reusable partial with the remotes table markup
- render the remotes table beneath the creation form on the rclone configuration view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc944f3cb083329d923fd45f45ed19