### PR TITLE
Persist rclone configuration across container restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 backups/
+rcloneConfig/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Orquestador liviano que:
 backup-orchestrator/
 ├─ docker-compose.yml
 ├─ .env                # variables del orquestador
+├─ rcloneConfig/       # configuración persistente de rclone
 └─ orchestrator/
    ├─ Dockerfile       # imagen con app + rclone
    └─ app/            # código del orquestador (UI + scheduler + runner)
@@ -51,9 +52,10 @@ RCLONE_REMOTE=gdrive
 # Cada app elige su carpeta destino; el orquestador guarda el folderId por app
 ```
 
-> El **remote** `gdrive` se configura una sola vez y vive en el volumen `rclone_config`.
+> El **remote** `gdrive` se configura una sola vez y vive en `./rcloneConfig` (montado en `/config/rclone` dentro del contenedor).
 
 ## 4) Primer arranque
+El `docker-compose` monta `./rcloneConfig` dentro del contenedor para conservar la configuración de rclone entre reinicios. La carpeta se crea automáticamente al levantar los servicios (o podés crearla manualmente con `mkdir -p rcloneConfig`).
 ```bash
 docker compose up -d --build
 ```
@@ -75,7 +77,7 @@ docker exec -it backup-orchestrator rclone lsd gdrive:
 Si preferís evitar la consola, la interfaz web incluye una sección para inicializar y ver los remotes de rclone.
 - Ingresá a **Rclone → Configurar** desde la UI.
 - Allí se ejecuta el asistente `rclone config` y podés listar los remotes disponibles (`/rclone/remotes`).
-- La configuración se guarda en el volumen `rclone_config`.
+- La configuración se guarda en `./rcloneConfig`, por lo que no se pierde al reiniciar el contenedor.
 
 ## 7) Contrato v1 para las Apps
 Cada app que quiera respaldo debe conectarse a `backups_net` y exponer los

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - .env
     volumes:
       - backups:/backups
+      - ./rcloneConfig:/config/rclone
     networks:
       - backups_net
       - Backuper_tunn_net


### PR DESCRIPTION
## Summary
- bind mount `./rcloneConfig` into `/config/rclone` so rclone keeps its configuration across container recreations
- document the persistent configuration directory in the README
- ignore the host-side `rcloneConfig` directory in git to avoid committing credentials

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccdb59f748833280d1587b78015da2