### PR TITLE
Improve SFTP remote configuration flow

### DIFF
--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -636,6 +636,7 @@ def create_app() -> Flask:
                     "error": "Seleccioná la carpeta del servidor SFTP donde se crearán los respaldos.",
                 }, 400
             normalized_base = _normalize_sftp_base_path(base_path)
+            share_url = normalized_base
             try:
                 target_path = _join_sftp_folder(normalized_base, name)
             except ValueError:

--- a/orchestrator/app/static/js/remotes.js
+++ b/orchestrator/app/static/js/remotes.js
@@ -83,9 +83,20 @@ function resetSftpBrowser(clearSelection = true) {
   if (panel) {
     panel.classList.add('d-none');
   }
-  const list = document.getElementById('sftp-directory-list');
-  if (list) {
-    list.innerHTML = '';
+  const select = document.getElementById('sftp-directory-select');
+  if (select) {
+    select.innerHTML = '';
+    select.disabled = true;
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Probá la conexión para listar carpetas';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    select.appendChild(placeholder);
+  }
+  const openButton = document.getElementById('sftp-open-selected');
+  if (openButton) {
+    openButton.disabled = true;
   }
   const emptyAlert = document.getElementById('sftp-empty');
   if (emptyAlert) {
@@ -99,7 +110,7 @@ function resetSftpBrowser(clearSelection = true) {
   if (upButton) {
     upButton.disabled = true;
   }
-  updateSftpStatus('Completá las credenciales y listá las carpetas disponibles.', 'muted');
+  updateSftpStatus('Completá las credenciales y probá la conexión para ver las carpetas disponibles.', 'muted');
   if (clearSelection) {
     updateSftpSelectedPath('');
   }
@@ -130,15 +141,16 @@ async function fetchSftpDirectories(path) {
 
 function renderSftpBrowser(data) {
   const panel = document.getElementById('sftp-browser-panel');
-  const list = document.getElementById('sftp-directory-list');
+  const select = document.getElementById('sftp-directory-select');
   const emptyAlert = document.getElementById('sftp-empty');
   const currentPathLabel = document.getElementById('sftp-current-path');
   const upButton = document.getElementById('sftp-browser-up');
-  if (!panel || !list || !currentPathLabel) {
+  const openButton = document.getElementById('sftp-open-selected');
+  if (!panel || !select || !currentPathLabel) {
     return;
   }
   panel.classList.remove('d-none');
-  list.innerHTML = '';
+  select.innerHTML = '';
   const directories = Array.isArray(data.directories) ? data.directories : [];
   sftpState.currentPath = normalizeSftpPath(data.current_path);
   sftpState.parentPath = normalizeSftpPath(data.parent_path);
@@ -150,11 +162,27 @@ function renderSftpBrowser(data) {
     if (emptyAlert) {
       emptyAlert.classList.remove('d-none');
     }
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'No hay subcarpetas disponibles';
+    option.disabled = true;
+    option.selected = true;
+    select.appendChild(option);
+    select.disabled = true;
+    if (openButton) {
+      openButton.disabled = true;
+    }
     return;
   }
   if (emptyAlert) {
     emptyAlert.classList.add('d-none');
   }
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Seleccioná una subcarpeta…';
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  select.appendChild(placeholder);
   directories
     .slice()
     .sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }))
@@ -162,13 +190,15 @@ function renderSftpBrowser(data) {
       if (!entry || !entry.name || !entry.path) {
         return;
       }
-      const item = document.createElement('button');
-      item.type = 'button';
-      item.className = 'list-group-item list-group-item-action';
-      item.textContent = entry.name;
-      item.dataset.path = entry.path;
-      list.appendChild(item);
+      const option = document.createElement('option');
+      option.value = entry.path;
+      option.textContent = entry.name;
+      select.appendChild(option);
     });
+  select.disabled = false;
+  if (openButton) {
+    openButton.disabled = true;
+  }
 }
 
 async function openSftpPath(path) {
@@ -180,17 +210,18 @@ async function openSftpPath(path) {
   const data = await fetchSftpDirectories(path);
   if (data) {
     renderSftpBrowser(data);
-    updateSftpStatus('Seleccioná la carpeta donde querés guardar los respaldos.', 'muted');
+    updateSftpStatus('Seleccioná una carpeta del menú desplegable o navegá con "Ver subcarpetas".', 'muted');
   }
 }
 
 function initSftpBrowser() {
   resetSftpBrowser(true);
   const browseButton = document.getElementById('sftp-browse');
-  const list = document.getElementById('sftp-directory-list');
+  const directorySelect = document.getElementById('sftp-directory-select');
   const upButton = document.getElementById('sftp-browser-up');
   const useButton = document.getElementById('sftp-use-current');
-  if (!browseButton || !list || !upButton || !useButton) {
+  const openButton = document.getElementById('sftp-open-selected');
+  if (!browseButton || !directorySelect || !upButton || !useButton || !openButton) {
     return;
   }
 
@@ -200,7 +231,7 @@ function initSftpBrowser() {
     const username = document.getElementById('sftp_username')?.value.trim() || '';
     const password = document.getElementById('sftp_password')?.value || '';
     if (!host || !username || !password) {
-      updateSftpStatus('Completá host, usuario y contraseña antes de listar las carpetas.', 'danger');
+      updateSftpStatus('Completá host, usuario y contraseña antes de probar la conexión.', 'danger');
       return;
     }
     if (portValue && !/^\d+$/.test(portValue)) {
@@ -218,7 +249,7 @@ function initSftpBrowser() {
       const data = await fetchSftpDirectories('/');
       if (data) {
         renderSftpBrowser(data);
-        updateSftpStatus('Seleccioná la carpeta donde querés guardar los respaldos.', 'muted');
+        updateSftpStatus('Seleccioná una carpeta del menú desplegable o navegá con "Ver subcarpetas".', 'muted');
       }
     } catch (err) {
       updateSftpStatus('No se pudieron listar las carpetas del servidor SFTP.', 'danger');
@@ -227,17 +258,35 @@ function initSftpBrowser() {
     }
   });
 
-  list.addEventListener('click', async (event) => {
-    const target = event.target instanceof Element ? event.target.closest('button[data-path]') : null;
-    if (!target) {
+  const handleOpenSelected = async () => {
+    if (!directorySelect.value) {
+      updateSftpStatus('Elegí una subcarpeta del menú desplegable para continuar.', 'danger');
       return;
     }
-    const { path } = target.dataset;
-    if (!path) {
-      return;
+    await openSftpPath(directorySelect.value);
+  };
+
+  directorySelect.addEventListener('change', () => {
+    if (openButton) {
+      openButton.disabled = !directorySelect.value;
     }
-    await openSftpPath(path);
   });
+
+  directorySelect.addEventListener('dblclick', async () => {
+    if (!directorySelect.value) {
+      return;
+    }
+    await openSftpPath(directorySelect.value);
+  });
+
+  directorySelect.addEventListener('keydown', async (event) => {
+    if (event.key === 'Enter' && directorySelect.value) {
+      event.preventDefault();
+      await openSftpPath(directorySelect.value);
+    }
+  });
+
+  openButton.addEventListener('click', handleOpenSelected);
 
   upButton.addEventListener('click', async () => {
     if (upButton.disabled) {
@@ -319,6 +368,7 @@ async function loadRemotes() {
       const remote = typeof entry === 'string' ? { name: entry } : entry || {};
       const name = remote.name || '';
       const shareUrl = remote.share_url || '';
+      const remoteType = (remote.type || '').toLowerCase();
       if (tbody) {
         const tr = document.createElement('tr');
         const nameCell = document.createElement('td');
@@ -326,13 +376,20 @@ async function loadRemotes() {
         tr.appendChild(nameCell);
         const linkCell = document.createElement('td');
         if (shareUrl) {
-          const anchor = document.createElement('a');
-          anchor.href = shareUrl;
-          anchor.target = '_blank';
-          anchor.rel = 'noopener';
-          anchor.textContent = shareUrl;
-          anchor.classList.add('text-break');
-          linkCell.appendChild(anchor);
+          if (remoteType === 'sftp') {
+            const span = document.createElement('span');
+            span.textContent = shareUrl;
+            span.classList.add('text-break');
+            linkCell.appendChild(span);
+          } else {
+            const anchor = document.createElement('a');
+            anchor.href = shareUrl;
+            anchor.target = '_blank';
+            anchor.rel = 'noopener';
+            anchor.textContent = shareUrl;
+            anchor.classList.add('text-break');
+            linkCell.appendChild(anchor);
+          }
         } else {
           linkCell.textContent = '—';
           linkCell.classList.add('text-muted');

--- a/orchestrator/app/templates/partials/remotes_table.html
+++ b/orchestrator/app/templates/partials/remotes_table.html
@@ -3,7 +3,7 @@
     <thead>
       <tr>
         <th scope="col">Nombre</th>
-        <th scope="col">Enlace compartido</th>
+        <th scope="col">Ruta o enlace</th>
       </tr>
     </thead>
     <tbody></tbody>

--- a/orchestrator/app/templates/rclone_config.html
+++ b/orchestrator/app/templates/rclone_config.html
@@ -57,7 +57,7 @@
 
       <div class="remote-panel d-none" data-remote-panel="sftp">
         <h2 class="h5">Servidor SFTP</h2>
-        <p class="text-muted">Ingresá los datos de conexión. Vamos a probar el acceso y crear una carpeta con el nombre del remote para guardar los respaldos.</p>
+        <p class="text-muted">Ingresá los datos de conexión. Primero probamos el acceso y, si es exitoso, podés elegir la carpeta donde se crearán los respaldos.</p>
         <div class="row g-3">
           <div class="col-md-6">
             <label for="sftp_host" class="form-label">Host</label>
@@ -77,7 +77,35 @@
           </div>
         </div>
         <div class="form-text mt-2">
-          Si dejás el puerto vacío se usará el valor por defecto (22). La carpeta <code>&lt;nombre del remote&gt;</code> se creará automáticamente en el servidor remoto.
+          Si dejás el puerto vacío se usará el valor por defecto (22). La carpeta <code>&lt;nombre del remote&gt;</code> se creará automáticamente dentro de la ruta que elijas.
+        </div>
+        <div class="mt-3">
+          <button type="button" class="btn btn-outline-secondary" id="sftp-browse">Establecer conexión y listar carpetas</button>
+          <div id="sftp-browser-feedback" class="form-text mt-2 text-muted"></div>
+        </div>
+        <div id="sftp-browser-panel" class="border rounded p-3 mt-3 d-none">
+          <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+            <div><span class="fw-semibold">Carpeta actual:</span> <span id="sftp-current-path">/</span></div>
+            <div class="d-flex gap-2 flex-wrap">
+              <button type="button" class="btn btn-sm btn-outline-secondary" id="sftp-browser-up" disabled>Subir un nivel</button>
+              <button type="button" class="btn btn-sm btn-success" id="sftp-use-current">Usar esta carpeta</button>
+            </div>
+          </div>
+          <div class="mt-3">
+            <label for="sftp-directory-select" class="form-label">Subcarpetas disponibles</label>
+            <div class="d-flex flex-wrap gap-2 align-items-start">
+              <select class="form-select" id="sftp-directory-select" disabled></select>
+              <button type="button" class="btn btn-outline-secondary" id="sftp-open-selected">Ver subcarpetas</button>
+            </div>
+            <div class="form-text mt-2">Elegí una subcarpeta del menú desplegable o usá la carpeta actual para guardar los respaldos.</div>
+          </div>
+          <div id="sftp-empty" class="alert alert-warning mt-3 d-none" role="alert">
+            No encontramos subcarpetas en esta ubicación. Podés usarla igual para guardar los respaldos.
+          </div>
+        </div>
+        <input type="hidden" id="sftp_base_path" value="">
+        <div id="sftp-selected-path" class="form-text mt-2 text-muted">
+          Todavía no elegiste la carpeta donde se crearán los respaldos.
         </div>
       </div>
 

--- a/tests/test_rclone_api.py
+++ b/tests/test_rclone_api.py
@@ -479,7 +479,7 @@ def test_create_sftp_remote_success(monkeypatch, app):
         },
     )
     assert resp.status_code == 201
-    assert resp.get_json() == {"status": "ok"}
+    assert resp.get_json() == {"status": "ok", "share_url": "/data"}
     assert len(calls) == 3
     config_cmd, mkdir_cmd, lsd_cmd = calls
     assert config_cmd[3:7] == ["config", "create", "--non-interactive", "sftpbackup"]

--- a/tests/test_rclone_authorize.py
+++ b/tests/test_rclone_authorize.py
@@ -204,7 +204,7 @@ def test_create_sftp_remote_success(monkeypatch):
     }
     resp = client.post("/rclone/remotes", json=payload)
     assert resp.status_code == 201
-    assert resp.get_json() == {"status": "ok"}
+    assert resp.get_json() == {"status": "ok", "share_url": "/srv/backups"}
     assert len(calls) == 3
     create_cmd = calls[0]["cmd"]
     assert create_cmd[0] == "rclone"


### PR DESCRIPTION
## Summary
- add a connect-and-browse flow with dropdown navigation for SFTP remotes
- persist the selected SFTP base path and show it in the remotes table
- adjust tests to cover the new SFTP metadata expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd80866b0c8332a48d06d83bd51c03