### PR TITLE
Persist remote routes and improve SFTP remote management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends rclone \
     && rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p /data
+
 WORKDIR /app
 
 # Install Python dependencies

--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ backup-orchestrator/
    └─ app/            # código del orquestador (UI + scheduler + runner)
 ```
 
+### ¿Para qué usamos el volumen `backups`?
+
+El servicio define un volumen Docker llamado `backups` que se monta dentro del
+contenedor en la ruta `/backups`. Ese espacio queda disponible para que el
+orquestador exponga carpetas locales mediante la funcionalidad **Local** de los
+remotes de rclone. Si configurás la variable `RCLONE_LOCAL_DIRECTORIES`
+(por ejemplo `RCLONE_LOCAL_DIRECTORIES=Respaldos|/backups/mi-app`), la UI
+permitirá elegir esas rutas como destino y los archivos quedarán almacenados en
+el volumen persistente del host.
+
+### ¿Para qué usamos la base de datos?
+
+El orquestador guarda su configuración en una base SQLite (o en la base que
+indique `DATABASE_URL`). Allí se almacenan las aplicaciones registradas, sus
+programaciones y también los metadatos de cada remote configurado (tipo, ruta
+de destino, enlace compartido, etc.). De esta manera, toda la información sigue
+disponible aunque el contenedor se reinicie o se vuelva a construir. Para evitar
+perder esos datos, el `docker-compose.yml` monta un volumen llamado
+`orchestrator_db` sobre `/data` dentro del contenedor y fija
+`DATABASE_URL=sqlite:////data/apps.db`, por lo que el archivo `apps.db` queda en
+un volumen persistente del host.
+
 ## 3) Variables (.env)
 Crear un archivo `.env` en la raíz:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,18 @@ services:
     container_name: backuper
     env_file:
       - .env
+    environment:
+      DATABASE_URL: sqlite:////data/apps.db
     volumes:
       - backups:/backups
       - ./rcloneConfig:/config/rclone
+      - orchestrator_db:/data
     networks:
       - backups_net
       - Backuper_tunn_net
 volumes:
   backups:
+  orchestrator_db:
 networks:
   backups_net:
     driver: bridge

--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -225,6 +225,7 @@ def create_app() -> Flask:
                 raise RemoteOperationError("path is required")
             if path not in directories:
                 raise RemoteOperationError("invalid path")
+            plan.share_url = path
             plan.command = [*base_args, "alias", "remote", path]
         elif normalized_type == "sftp":
             host = (settings.get("host") or "").strip()
@@ -580,8 +581,10 @@ def create_app() -> Flask:
             if stored_remote:
                 if stored_remote.type:
                     item["type"] = stored_remote.type
-                if stored_remote.share_url:
-                    item["share_url"] = stored_remote.share_url
+                route = (stored_remote.route or "").strip()
+                if route:
+                    item["route"] = route
+                    item["share_url"] = route
             entries.append(item)
         return jsonify(entries)
 
@@ -786,18 +789,18 @@ def create_app() -> Flask:
             existing = db.query(RcloneRemote).filter_by(name=name).one_or_none()
             if existing:
                 existing.type = remote_type
-                existing.share_url = share_url
+                existing.route = share_url
             else:
                 db.add(
                     RcloneRemote(
                         name=name,
                         type=remote_type,
-                        share_url=share_url,
+                        route=share_url,
                     )
                 )
             db.commit()
 
-        response = {"status": "ok"}
+        response = {"status": "ok", "route": share_url}
         if share_url:
             response["share_url"] = share_url
         return response, 201
@@ -890,18 +893,18 @@ def create_app() -> Flask:
             existing = db.query(RcloneRemote).filter_by(name=normalized_name).one_or_none()
             if existing:
                 existing.type = remote_type
-                existing.share_url = share_url
+                existing.route = share_url
             else:
                 db.add(
                     RcloneRemote(
                         name=normalized_name,
                         type=remote_type,
-                        share_url=share_url,
+                        route=share_url,
                     )
                 )
             db.commit()
 
-        response = {"status": "ok"}
+        response = {"status": "ok", "route": share_url}
         if share_url:
             response["share_url"] = share_url
         return response, 200

--- a/orchestrator/app/models.py
+++ b/orchestrator/app/models.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from sqlalchemy import Column, Integer, String
 
 from .database import Base
@@ -27,3 +29,19 @@ class RcloneRemote(Base):
     name = Column(String, unique=True, nullable=False)
     type = Column(String, nullable=True)
     share_url = Column(String, nullable=True)
+
+    @property
+    def route(self) -> Optional[str]:
+        """Alias legible para el campo ``share_url``.
+
+        En la base seguimos guardando el valor en ``share_url`` para mantener la
+        compatibilidad con instalaciones existentes, pero la lógica de la
+        aplicación puede trabajar con ``route`` para representar tanto enlaces
+        como rutas locales.
+        """
+
+        return self.share_url
+
+    @route.setter
+    def route(self, value: Optional[str]) -> None:
+        self.share_url = value

--- a/tests/test_rclone_authorize.py
+++ b/tests/test_rclone_authorize.py
@@ -144,7 +144,11 @@ def test_create_local_remote(monkeypatch):
     }
     resp = client.post("/rclone/remotes", json=payload)
     assert resp.status_code == 201
-    assert resp.get_json() == {"status": "ok"}
+    assert resp.get_json() == {
+        "status": "ok",
+        "route": "/data/backups",
+        "share_url": "/data/backups",
+    }
     cmd = recorded["cmd"]
     assert cmd[:3] == ["rclone", "--config", "/tmp/test-rclone.conf"]
     assert "--non-interactive" in cmd
@@ -204,7 +208,11 @@ def test_create_sftp_remote_success(monkeypatch):
     }
     resp = client.post("/rclone/remotes", json=payload)
     assert resp.status_code == 201
-    assert resp.get_json() == {"status": "ok", "share_url": "/srv/backups"}
+    assert resp.get_json() == {
+        "status": "ok",
+        "route": "/srv/backups",
+        "share_url": "/srv/backups",
+    }
     assert len(calls) == 3
     create_cmd = calls[0]["cmd"]
     assert create_cmd[0] == "rclone"


### PR DESCRIPTION
## Summary
- document why the `backups` volume and database are mounted so their purpose is clear
- persist each rclone remote's destination path or share link in the database and expose it through the API
- fix the remotes UI so routes render correctly, keep the SFTP browser working, and surface the saved path after saving or editing
- update tests to reflect the new metadata returned by the API
- persist the orchestrator's SQLite database on a dedicated `/data` volume so it survives container rebuilds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd8e7f0efc8332b986f410fa659821