### PR TITLE
Complete local remote lifecycle handling

### DIFF
--- a/orchestrator/app/templates/partials/remotes_table.html
+++ b/orchestrator/app/templates/partials/remotes_table.html
@@ -4,6 +4,7 @@
       <tr>
         <th scope="col">Nombre</th>
         <th scope="col">Ruta o enlace</th>
+        <th scope="col" class="text-end">Acciones</th>
       </tr>
     </thead>
     <tbody></tbody>

--- a/orchestrator/app/templates/rclone_config.html
+++ b/orchestrator/app/templates/rclone_config.html
@@ -21,6 +21,11 @@
   <p class="mt-3 mb-0" id="remote-loading-text">Procesando…</p>
 </div>
 <div class="container py-4">
+  <div
+    id="remote-config-data"
+    class="d-none"
+    data-admin-email="{{ admin_email|default('', true)|trim }}"
+  ></div>
   <h1 class="mb-4">Configurar remote de Rclone</h1>
   <form id="remote-form" class="mt-3" novalidate>
     <div class="row g-3">
@@ -45,10 +50,16 @@
     <div class="mt-4" id="remote-type-panels">
       <div class="remote-panel d-none" data-remote-panel="local">
         <h2 class="h5">Destino local</h2>
-        <p class="text-muted">Seleccioná una carpeta preconfigurada del servidor donde se guardarán los respaldos.</p>
+        <p class="text-muted">
+          Seleccioná una carpeta preconfigurada del servidor donde se guardarán los respaldos.
+          Vamos a crear una subcarpeta con el nombre del remote dentro de la ruta elegida.
+        </p>
         <div class="mb-3">
           <label for="local_path" class="form-label">Carpeta disponible</label>
           <select class="form-select" id="local_path"></select>
+        </div>
+        <div id="local-path-summary" class="form-text text-muted">
+          Elegí una carpeta disponible para preparar el remote.
         </div>
         <div id="local-empty" class="alert alert-warning d-none" role="alert">
           No hay carpetas locales configuradas. Agregalas en la configuración del contenedor.
@@ -186,5 +197,46 @@
     {% include 'partials/remotes_table.html' %}
   </div>
 
+</div>
+
+<div
+  class="modal fade"
+  id="remote-delete-modal"
+  tabindex="-1"
+  aria-labelledby="remote-delete-modal-title"
+  aria-describedby="remote-delete-description remote-delete-impact"
+  aria-hidden="true"
+>
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 class="modal-title fs-5" id="remote-delete-modal-title">Eliminar remote</h2>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body">
+        <p id="remote-delete-description" class="mb-1">
+          Vas a eliminar el remote <span class="fw-semibold" id="remote-delete-name"></span>.
+        </p>
+        <p id="remote-delete-impact" class="mb-3">
+          Esta acción borrará la configuración y todos los archivos guardados en su carpeta local.
+        </p>
+        <div id="remote-delete-route-wrapper" class="alert alert-warning d-none" role="alert">
+          <p class="mb-0">
+            Se eliminará la carpeta <span class="fw-semibold text-break" id="remote-delete-route"></span> junto con todo su contenido.
+          </p>
+        </div>
+        <p class="mb-0">
+          Si necesitás conservar los archivos, contactate con el administrador antes de continuar.
+        </p>
+        <p class="mb-0 mt-2 d-none" id="remote-delete-admin-wrapper">
+          Podés escribirle a <a id="remote-delete-admin-email" href=""></a> para coordinar la preservación de los datos.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-danger" id="remote-delete-confirm">Sí, eliminar remote</button>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- harden local remote lifecycle server-side by normalizing filesystem paths, moving or restoring folders on rename/delete, and exposing the admin contact in the template
- refresh the remotes UI to preview target folders, support renaming, provide a bootstrap delete modal, and surface action controls
- expand API coverage for local remotes using temporary directories to assert folder creation, movement, and removal

## Testing
- pytest tests/test_rclone_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cd96d717108332a0af76f939f86752