### PR TITLE
Fix rclone directory listing flag

### DIFF
--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -237,7 +237,7 @@ def create_app() -> Flask:
     def _collect_drive_root_entries(remote: str) -> set[str]:
         entries: set[str] = set()
         base_args = ["lsf", remote, "--max-depth", "1"]
-        for flag in ("--dir-only", "--files-only"):
+        for flag in ("--dirs-only", "--files-only"):
             try:
                 result = run_rclone(
                     [*base_args, flag], capture_output=True, text=True, check=True

--- a/tests/test_rclone_api.py
+++ b/tests/test_rclone_api.py
@@ -994,6 +994,8 @@ def test_create_rclone_remote_shared_share_failure(monkeypatch, app):
         if cmd[-1] == "listremotes":
             return DummyResult(stdout="gdrive:\n")
         if len(cmd) > 3 and cmd[3] == "lsf":
+            assert "--dir-only" not in cmd
+            assert any(flag in cmd for flag in ("--dirs-only", "--files-only"))
             return DummyResult(stdout="")
         if "mkdir" in cmd:
             return DummyResult()
@@ -1029,6 +1031,8 @@ def test_create_rclone_remote_shared_missing_share_url(monkeypatch, app):
         if cmd[-1] == "listremotes":
             return DummyResult(stdout="gdrive:\n")
         if len(cmd) > 3 and cmd[3] == "lsf":
+            assert "--dir-only" not in cmd
+            assert any(flag in cmd for flag in ("--dirs-only", "--files-only"))
             return DummyResult(stdout="")
         if "mkdir" in cmd:
             return DummyResult()


### PR DESCRIPTION
## Summary
- replace the unsupported `rclone lsf` flag with `--dirs-only` when collecting Drive entries
- extend Drive remote tests to ensure only supported listing flags are used

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdb63c023c833298244fc4c4433322