### PR TITLE
Handle rclone config backup without unsupported flags

### DIFF
--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -237,7 +237,7 @@ def create_app() -> Flask:
     def _collect_drive_root_entries(remote: str) -> set[str]:
         entries: set[str] = set()
         base_args = ["lsf", remote, "--max-depth", "1"]
-        for flag in ("--dir-only", "--files-only"):
+        for flag in ("--dirs-only", "--files-only"):
             try:
                 result = run_rclone(
                     [*base_args, flag], capture_output=True, text=True, check=True
@@ -638,6 +638,12 @@ def create_app() -> Flask:
 
     def _restore_remote_backup(remote_name: str, backup_name: str) -> bool:
         try:
+            backup_config = _load_remote_configuration(backup_name)
+        except (RemoteOperationError, RuntimeError):
+            return False
+        if not backup_config:
+            return False
+        try:
             run_rclone(
                 ["config", "delete", remote_name],
                 capture_output=True,
@@ -650,13 +656,8 @@ def create_app() -> Flask:
             return False
 
         try:
-            run_rclone(
-                ["config", "copy", backup_name, remote_name],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-        except (subprocess.CalledProcessError, RuntimeError):
+            _apply_remote_configuration(remote_name, backup_config)
+        except (RemoteOperationError, subprocess.CalledProcessError, RuntimeError):
             return False
         return True
 
@@ -670,6 +671,73 @@ def create_app() -> Flask:
             )
         except (subprocess.CalledProcessError, RuntimeError):
             pass
+
+    def _load_remote_configuration(remote_name: str) -> dict[str, str] | None:
+        try:
+            result = run_rclone(
+                ["config", "dump"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            message = (exc.stderr or exc.stdout or "").strip() or "No se pudo leer la configuración de rclone."
+            raise RemoteOperationError(message, 500) from exc
+        raw_output = (result.stdout or "").strip()
+        try:
+            payload = json.loads(raw_output or "{}")
+        except json.JSONDecodeError as exc:
+            raise RemoteOperationError(
+                "No se pudo interpretar la configuración de rclone.",
+                500,
+            ) from exc
+        entry = payload.get(remote_name)
+        if entry is None:
+            return None
+        if not isinstance(entry, dict):
+            raise RemoteOperationError(
+                "La configuración del remote tiene un formato desconocido.",
+                500,
+            )
+        config: dict[str, str] = {}
+        for key, value in entry.items():
+            if value is None:
+                continue
+            config[str(key)] = str(value)
+        return config
+
+    def _apply_remote_configuration(remote_name: str, config: dict[str, str]) -> None:
+        remote_type = (config.get("type") or "").strip()
+        if not remote_type:
+            raise RemoteOperationError(
+                "No se pudo determinar el tipo del remote en la copia de seguridad.",
+                500,
+            )
+        args: list[str] = [
+            "config",
+            "create",
+            "--non-interactive",
+            remote_name,
+            remote_type,
+        ]
+        for key, value in config.items():
+            if key in {"type", "name"}:
+                continue
+            args.extend([key, str(value)])
+        run_rclone(args, capture_output=True, text=True, check=True)
+
+    def _clone_remote_configuration(
+        source_name: str,
+        target_name: str,
+        *,
+        error_message: str | None = None,
+    ) -> None:
+        config = _load_remote_configuration(source_name)
+        if config is None:
+            raise RemoteOperationError(
+                error_message or "No se pudo replicar la configuración del remote.",
+            )
+        _apply_remote_configuration(target_name, config)
 
     def login_required(func):
         @wraps(func)
@@ -1268,14 +1336,16 @@ def create_app() -> Flask:
 
         backup_name = f"__backup__{uuid.uuid4().hex[:8]}"
         try:
-            run_rclone(
-                ["config", "copy", normalized_name, backup_name],
-                capture_output=True,
-                text=True,
-                check=True,
+            _clone_remote_configuration(
+                normalized_name,
+                backup_name,
+                error_message="No se pudo preparar la edición del remote.",
             )
         except RuntimeError:
             return {"error": "rclone is not installed"}, 500
+        except RemoteOperationError as exc:
+            _delete_remote_safely(backup_name)
+            return {"error": str(exc)}, exc.status_code
         except subprocess.CalledProcessError as exc:
             message = (exc.stderr or exc.stdout or "").strip() or "No se pudo preparar la edición del remote."
             _delete_remote_safely(backup_name)
@@ -1611,14 +1681,16 @@ def create_app() -> Flask:
         if requires_backup:
             backup_name = f"__delete__{uuid.uuid4().hex[:8]}"
             try:
-                run_rclone(
-                    ["config", "copy", normalized_name, backup_name],
-                    capture_output=True,
-                    text=True,
-                    check=True,
+                _clone_remote_configuration(
+                    normalized_name,
+                    backup_name,
+                    error_message="No se pudo preparar la eliminación del remote.",
                 )
             except RuntimeError:
                 return {"error": "rclone is not installed"}, 500
+            except RemoteOperationError as exc:
+                _delete_remote_safely(backup_name)
+                return {"error": str(exc)}, exc.status_code
             except subprocess.CalledProcessError as exc:
                 message = (exc.stderr or exc.stdout or "").strip() or "No se pudo preparar la eliminación del remote."
                 _delete_remote_safely(backup_name)

--- a/tests/test_rclone_api.py
+++ b/tests/test_rclone_api.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import subprocess
@@ -413,10 +414,29 @@ def test_update_rclone_remote_local_success(monkeypatch, app, tmp_path):
             self.stdout = stdout
             self.stderr = stderr
 
+    config_entries = {
+        "foo": {"type": "alias", "remote": str(tmp_path / "foo")},
+    }
+
     def fake_run(cmd, capture_output, text, check):
         commands.append(cmd)
         if cmd[-1] == "listremotes":
             return DummyResult(stdout="foo:\n")
+        if len(cmd) >= 5 and cmd[3] == "config" and cmd[4] == "dump":
+            return DummyResult(stdout=json.dumps(config_entries))
+        if len(cmd) >= 6 and cmd[3] == "config" and cmd[4] == "delete":
+            config_entries.pop(cmd[5], None)
+            return DummyResult()
+        if len(cmd) >= 8 and cmd[3] == "config" and cmd[4] == "create":
+            name = cmd[6]
+            remote_type = cmd[7]
+            options: dict[str, str] = {}
+            for idx in range(8, len(cmd), 2):
+                if idx + 1 >= len(cmd):
+                    break
+                options[cmd[idx]] = cmd[idx + 1]
+            config_entries[name] = {"type": remote_type, **options}
+            return DummyResult()
         return DummyResult()
 
     monkeypatch.setenv("RCLONE_LOCAL_DIRECTORIES", str(tmp_path))
@@ -442,17 +462,33 @@ def test_update_rclone_remote_local_success(monkeypatch, app, tmp_path):
 
     config_path = os.getenv("RCLONE_CONFIG")
     assert commands[0] == ["rclone", "--config", config_path, "listremotes"]
-    assert commands[1][:6] == ["rclone", "--config", config_path, "config", "copy", "foo"]
-    backup_name = commands[1][6]
-    assert commands[2] == ["rclone", "--config", config_path, "config", "delete", "foo"]
+    dump_cmd = commands[1]
+    assert dump_cmd[:5] == ["rclone", "--config", config_path, "config", "dump"]
+    backup_create_cmd = next(
+        cmd
+        for cmd in commands
+        if len(cmd) >= 8
+        and cmd[3] == "config"
+        and cmd[4] == "create"
+        and cmd[6].startswith("__backup__")
+    )
+    backup_name = backup_create_cmd[6]
+    assert backup_create_cmd[:8] == [
+        "rclone",
+        "--config",
+        config_path,
+        "config",
+        "create",
+        "--non-interactive",
+        backup_name,
+        "alias",
+    ]
+    delete_cmd = ["rclone", "--config", config_path, "config", "delete", "foo"]
+    assert delete_cmd in commands
     create_cmd = next(
         cmd
         for cmd in commands
-        if cmd[:9]
-        == [
-            "rclone",
-            "--config",
-            config_path,
+        if len(cmd) >= 10 and cmd[3:9] == [
             "config",
             "create",
             "--non-interactive",
@@ -461,17 +497,6 @@ def test_update_rclone_remote_local_success(monkeypatch, app, tmp_path):
             "remote",
         ]
     )
-    assert create_cmd[:9] == [
-        "rclone",
-        "--config",
-        config_path,
-        "config",
-        "create",
-        "--non-interactive",
-        "foo",
-        "alias",
-        "remote",
-    ]
     assert create_cmd[9] == str(expected_path)
     assert [
         "rclone",
@@ -501,12 +526,34 @@ def test_update_rclone_remote_failure_restores_backup(monkeypatch, app, tmp_path
             self.stdout = stdout
             self.stderr = stderr
 
+    config_entries = {
+        "foo": {"type": "alias", "remote": str(tmp_path / "foo")},
+    }
+    fail_next_create = True
+
     def fake_run(cmd, capture_output, text, check):
         commands.append(cmd)
         if cmd[-1] == "listremotes":
             return DummyResult(stdout="foo:\n")
-        if cmd[3:7] == ["config", "create", "--non-interactive", "foo"]:
-            raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+        if len(cmd) >= 5 and cmd[3] == "config" and cmd[4] == "dump":
+            return DummyResult(stdout=json.dumps(config_entries))
+        if len(cmd) >= 6 and cmd[3] == "config" and cmd[4] == "delete":
+            config_entries.pop(cmd[5], None)
+            return DummyResult()
+        if len(cmd) >= 8 and cmd[3] == "config" and cmd[4] == "create":
+            name = cmd[6]
+            remote_type = cmd[7]
+            nonlocal fail_next_create
+            if name == "foo" and fail_next_create:
+                fail_next_create = False
+                raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+            options: dict[str, str] = {}
+            for idx in range(8, len(cmd), 2):
+                if idx + 1 >= len(cmd):
+                    break
+                options[cmd[idx]] = cmd[idx + 1]
+            config_entries[name] = {"type": remote_type, **options}
+            return DummyResult()
         return DummyResult()
 
     monkeypatch.setenv("RCLONE_LOCAL_DIRECTORIES", str(tmp_path))
@@ -522,29 +569,57 @@ def test_update_rclone_remote_failure_restores_backup(monkeypatch, app, tmp_path
     assert resp.get_json() == {"error": "boom"}
 
     config_path = os.getenv("RCLONE_CONFIG")
-    backup_name = commands[1][6]
     assert commands[0] == ["rclone", "--config", config_path, "listremotes"]
-    assert commands[1][:6] == ["rclone", "--config", config_path, "config", "copy", "foo"]
-    assert commands[2] == ["rclone", "--config", config_path, "config", "delete", "foo"]
-    assert commands[3][3:7] == ["config", "create", "--non-interactive", "foo"]
-    assert commands[4] == ["rclone", "--config", config_path, "config", "delete", "foo"]
-    assert commands[5][:7] == [
+    initial_dump = commands[1]
+    assert initial_dump[:5] == ["rclone", "--config", config_path, "config", "dump"]
+    backup_create_cmd = next(
+        cmd
+        for cmd in commands
+        if len(cmd) >= 8
+        and cmd[3] == "config"
+        and cmd[4] == "create"
+        and cmd[6].startswith("__backup__")
+    )
+    backup_name = backup_create_cmd[6]
+    assert backup_create_cmd[:8] == [
         "rclone",
         "--config",
         config_path,
         "config",
-        "copy",
+        "create",
+        "--non-interactive",
         backup_name,
+        "alias",
+    ]
+    delete_cmd = ["rclone", "--config", config_path, "config", "delete", "foo"]
+    assert delete_cmd in commands
+    failure_cmd = commands[4]
+    assert failure_cmd[3:9] == [
+        "config",
+        "create",
+        "--non-interactive",
         "foo",
+        "alias",
+        "remote",
     ]
-    assert commands[6] == [
-        "rclone",
-        "--config",
-        config_path,
-        "config",
-        "delete",
-        backup_name,
-    ]
+    restore_dump = next(
+        cmd
+        for cmd in commands
+        if cmd[:5] == ["rclone", "--config", config_path, "config", "dump"]
+        and cmd is not initial_dump
+    )
+    assert restore_dump[:5] == ["rclone", "--config", config_path, "config", "dump"]
+    assert commands.count(["rclone", "--config", config_path, "config", "delete", backup_name]) == 1
+    restore_create_cmd = next(
+        cmd
+        for cmd in commands
+        if len(cmd) >= 8
+        and cmd[3] == "config"
+        and cmd[4] == "create"
+        and cmd[6] == "foo"
+        and cmd is not failure_cmd
+    )
+    assert restore_create_cmd[7] == "alias"
     assert not (tmp_path / "foo").exists()
 
 
@@ -578,10 +653,29 @@ def test_delete_rclone_remote_success(monkeypatch, app):
             self.stdout = stdout
             self.stderr = stderr
 
+    config_entries = {
+        "foo": {"type": "drive", "token": "tok", "scope": "drive"},
+    }
+
     def fake_run(cmd, capture_output, text, check):
         commands.append(cmd)
         if cmd[-1] == "listremotes":
             return DummyResult(stdout="foo:\n")
+        if len(cmd) >= 5 and cmd[3] == "config" and cmd[4] == "dump":
+            return DummyResult(stdout=json.dumps(config_entries))
+        if len(cmd) >= 6 and cmd[3] == "config" and cmd[4] == "delete":
+            config_entries.pop(cmd[5], None)
+            return DummyResult()
+        if len(cmd) >= 8 and cmd[3] == "config" and cmd[4] == "create":
+            name = cmd[6]
+            remote_type = cmd[7]
+            options: dict[str, str] = {}
+            for idx in range(8, len(cmd), 2):
+                if idx + 1 >= len(cmd):
+                    break
+                options[cmd[idx]] = cmd[idx + 1]
+            config_entries[name] = {"type": remote_type, **options}
+            return DummyResult()
         return DummyResult()
 
     from orchestrator.app import SessionLocal
@@ -600,13 +694,30 @@ def test_delete_rclone_remote_success(monkeypatch, app):
 
     config_path = os.getenv("RCLONE_CONFIG")
     assert commands[0] == ["rclone", "--config", config_path, "listremotes"]
-    assert commands[1][:6] == ["rclone", "--config", config_path, "config", "copy", "foo"]
-    backup_name = commands[1][6]
-    assert commands[2][:4] == ["rclone", "--config", config_path, "moveto"]
-    assert commands[3] == ["rclone", "--config", config_path, "config", "delete", "foo"]
-    assert commands[4][:3] == ["rclone", "--config", config_path]
-    assert commands[4][3] == "purge"
-    assert commands[5] == ["rclone", "--config", config_path, "config", "delete", backup_name]
+    dump_cmd = commands[1]
+    assert dump_cmd[:5] == ["rclone", "--config", config_path, "config", "dump"]
+    backup_create_cmd = next(
+        cmd
+        for cmd in commands
+        if len(cmd) >= 8
+        and cmd[3] == "config"
+        and cmd[4] == "create"
+        and cmd[6].startswith("__delete__")
+    )
+    backup_name = backup_create_cmd[6]
+    assert backup_create_cmd[7] == "drive"
+    assert ["rclone", "--config", config_path, "moveto"] in [cmd[:4] for cmd in commands]
+    assert ["rclone", "--config", config_path, "config", "delete", "foo"] in commands
+    purge_cmd = next(cmd for cmd in commands if len(cmd) >= 4 and cmd[3] == "purge")
+    assert purge_cmd[:3] == ["rclone", "--config", config_path]
+    assert [
+        "rclone",
+        "--config",
+        config_path,
+        "config",
+        "delete",
+        backup_name,
+    ] in commands
 
     with SessionLocal() as db:
         assert db.query(RcloneRemote).filter_by(name="foo").count() == 0
@@ -620,15 +731,35 @@ def test_delete_rclone_remote_local_removes_folder(monkeypatch, app, tmp_path):
             self.stdout = stdout
             self.stderr = stderr
 
+    config_entries = {
+        "foo": {"type": "alias", "remote": ""},
+    }
+
     def fake_run(cmd, capture_output, text, check):
         commands.append(cmd)
         if cmd[-1] == "listremotes":
             return DummyResult(stdout="foo:\n")
+        if len(cmd) >= 5 and cmd[3] == "config" and cmd[4] == "dump":
+            return DummyResult(stdout=json.dumps(config_entries))
+        if len(cmd) >= 6 and cmd[3] == "config" and cmd[4] == "delete":
+            config_entries.pop(cmd[5], None)
+            return DummyResult()
+        if len(cmd) >= 8 and cmd[3] == "config" and cmd[4] == "create":
+            name = cmd[6]
+            remote_type = cmd[7]
+            options: dict[str, str] = {}
+            for idx in range(8, len(cmd), 2):
+                if idx + 1 >= len(cmd):
+                    break
+                options[cmd[idx]] = cmd[idx + 1]
+            config_entries[name] = {"type": remote_type, **options}
+            return DummyResult()
         return DummyResult()
 
     base_folder = tmp_path
     remote_folder = base_folder / "foo"
     remote_folder.mkdir()
+    config_entries["foo"]["remote"] = str(remote_folder)
     monkeypatch.setenv("RCLONE_LOCAL_DIRECTORIES", str(base_folder))
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -662,11 +793,26 @@ def test_delete_rclone_remote_local_removes_folder(monkeypatch, app, tmp_path):
 
     config_path = os.getenv("RCLONE_CONFIG")
     assert commands[0] == ["rclone", "--config", config_path, "listremotes"]
-    copy_cmd = commands[1]
-    assert copy_cmd[:6] == ["rclone", "--config", config_path, "config", "copy", "foo"]
-    backup_name = copy_cmd[6]
-    assert commands[2] == ["rclone", "--config", config_path, "config", "delete", "foo"]
-    assert commands[3] == ["rclone", "--config", config_path, "config", "delete", backup_name]
+    dump_cmd = commands[1]
+    assert dump_cmd[:5] == ["rclone", "--config", config_path, "config", "dump"]
+    backup_create_cmd = next(
+        cmd
+        for cmd in commands
+        if len(cmd) >= 8
+        and cmd[3] == "config"
+        and cmd[4] == "create"
+        and cmd[6].startswith("__delete__")
+    )
+    backup_name = backup_create_cmd[6]
+    assert ["rclone", "--config", config_path, "config", "delete", "foo"] in commands
+    assert [
+        "rclone",
+        "--config",
+        config_path,
+        "config",
+        "delete",
+        backup_name,
+    ] in commands
 
     assert not remote_folder.exists()
 
@@ -994,6 +1140,8 @@ def test_create_rclone_remote_shared_share_failure(monkeypatch, app):
         if cmd[-1] == "listremotes":
             return DummyResult(stdout="gdrive:\n")
         if len(cmd) > 3 and cmd[3] == "lsf":
+            assert "--dir-only" not in cmd
+            assert any(flag in cmd for flag in ("--dirs-only", "--files-only"))
             return DummyResult(stdout="")
         if "mkdir" in cmd:
             return DummyResult()
@@ -1029,6 +1177,8 @@ def test_create_rclone_remote_shared_missing_share_url(monkeypatch, app):
         if cmd[-1] == "listremotes":
             return DummyResult(stdout="gdrive:\n")
         if len(cmd) > 3 and cmd[3] == "lsf":
+            assert "--dir-only" not in cmd
+            assert any(flag in cmd for flag in ("--dirs-only", "--files-only"))
             return DummyResult(stdout="")
         if "mkdir" in cmd:
             return DummyResult()


### PR DESCRIPTION
## Summary
- add helper utilities that duplicate and restore remotes using `rclone config dump`/`config create` instead of the unsupported `config copy`
- update the remote update/delete flows to call the new helpers and report clearer errors when backups cannot be prepared
- expand the rclone API tests to emulate the new command sequences and guard against regressions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdb63c023c833298244fc4c4433322