### PR TITLE
Persist remote configuration snapshots in the database

### DIFF
--- a/orchestrator/app/models.py
+++ b/orchestrator/app/models.py
@@ -1,6 +1,6 @@
 import datetime
 
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import Column, DateTime, Integer, String, Text
 
 from .database import Base
 
@@ -30,4 +30,5 @@ class RcloneRemote(Base):
     type = Column(String, nullable=True)
     route = Column(String, nullable=True)
     share_url = Column(String, nullable=True)
+    config = Column(Text, nullable=True)
     created_at = Column(DateTime, nullable=True, default=datetime.datetime.utcnow)


### PR DESCRIPTION
## Summary
- capture the configuration data for each remote directly when building the plan and persist it in the database
- favor database snapshots when loading and restoring rclone remotes so stored entries can be recreated without re-dumping configs
- refresh the rclone tests to validate the stored JSON payloads instead of depending on `config dump`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdcb5de2e88332be6e31a965bf29a3