### PR TITLE
Clean unused imports and dead assertions

### DIFF
--- a/tests/test_client_upload.py
+++ b/tests/test_client_upload.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 import tracemalloc
-import requests
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from orchestrator.services.client import BackupClient

--- a/tests/test_rclone_authorize.py
+++ b/tests/test_rclone_authorize.py
@@ -5,8 +5,6 @@ import importlib
 import subprocess
 from types import SimpleNamespace
 
-import pytest
-
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 
@@ -367,8 +365,18 @@ def test_create_sftp_remote_success(monkeypatch):
     assert "port" in create_cmd and create_cmd[create_cmd.index("port") + 1] == "2222"
     path_index = create_cmd.index("path")
     assert create_cmd[path_index + 1] == "/srv/backups/sftp1"
-    mkdir_cmd = next(call["cmd"] for call in calls if call["cmd"][3:] == ["mkdir", "sftp1:"])
-    lsd_cmd = next(call["cmd"] for call in calls if call["cmd"][3:] == ["lsd", "sftp1:"])
+    assert any(
+        len(call["cmd"]) > 4
+        and call["cmd"][:4] == ["rclone", "--config", config_path, "mkdir"]
+        and call["cmd"][4] == "sftp1:"
+        for call in calls
+    )
+    assert any(
+        len(call["cmd"]) > 4
+        and call["cmd"][:4] == ["rclone", "--config", config_path, "lsd"]
+        and call["cmd"][4] == "sftp1:"
+        for call in calls
+    )
     from orchestrator.app.models import RcloneRemote
 
     with app_module.SessionLocal() as db:  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- remove unused imports from the test suite and drop redundant variables
- replace unused command captures with explicit assertions about the expected rclone invocations
- adjust create-remote tests to focus on the commands the app actually executes while keeping behavioural checks intact

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdd9d50c808332a5d314ecc8ea7705