### PR TITLE
Ensure SQLite database persistence in docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ contenedor.
 El orquestador guarda su configuración en una base SQLite (o en la base que
 indique `DATABASE_URL`). Allí se almacenan las aplicaciones registradas, sus
 programaciones y también los metadatos de cada remote configurado (tipo, ruta
-de destino, enlace compartido, etc.). De esta manera, toda la información sigue
-disponible aunque el contenedor se reinicie o se vuelva a construir.
+de destino, enlace compartido, etc.). Por defecto, la base se crea en
+`./datosPersistentes/db/apps.db`, que es el directorio montado como
+`/datosPersistentes/db` dentro del contenedor según el `docker-compose`. Al
+usarse un bind mount, Docker no reemplaza ese archivo al reiniciar el servicio:
+la configuración permanece disponible aunque el contenedor se reinicie o se
+vuelva a construir. Si no existe, se genera automáticamente en esa misma ruta.
 
 ## 3) Variables (.env)
 Crear un archivo `.env` en la raíz:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: backuper
     env_file:
       - .env
+    environment:
+      DATABASE_URL: "${DATABASE_URL:-sqlite:////datosPersistentes/db/apps.db}"
     volumes:
       - backups:/backups
       - ./datosPersistentes/rcloneConfig:/config/rclone

--- a/tests/test_database_persistence.py
+++ b/tests/test_database_persistence.py
@@ -1,0 +1,63 @@
+import importlib
+import sys
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine.url import make_url
+
+
+@pytest.fixture
+def reload_database(monkeypatch):
+    module_name = "orchestrator.app.database"
+
+    def _reload(**env):
+        existing = sys.modules.pop(module_name, None)
+        if existing is not None:
+            engine = getattr(existing, "engine", None)
+            if engine is not None:
+                engine.dispose()
+        for key, value in env.items():
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, value)
+        module = importlib.import_module(module_name)
+        return module
+
+    yield _reload
+
+    existing = sys.modules.pop(module_name, None)
+    if existing is not None:
+        engine = getattr(existing, "engine", None)
+        if engine is not None:
+            engine.dispose()
+    importlib.import_module(module_name)
+
+
+def test_default_database_url_points_to_persistent_volume(reload_database):
+    database = reload_database(DATABASE_URL=None)
+    url = database.DATABASE_URL
+    parsed = make_url(url)
+
+    assert parsed.get_backend_name() == "sqlite"
+    assert parsed.database == "/datosPersistentes/db/apps.db"
+
+
+def test_existing_sqlite_database_is_reused(tmp_path, reload_database):
+    db_path = tmp_path / "persist" / "apps.db"
+    url = f"sqlite:///{db_path}"
+
+    database = reload_database(DATABASE_URL=url)
+    with database.engine.begin() as conn:
+        conn.execute(text("CREATE TABLE IF NOT EXISTS persisted (id INTEGER PRIMARY KEY, value TEXT)"))
+        conn.execute(text("INSERT INTO persisted (value) VALUES ('keep')"))
+
+    database.engine.dispose()
+
+    database = reload_database(DATABASE_URL=url)
+    with database.engine.connect() as conn:
+        result = conn.execute(text("SELECT value FROM persisted"))
+        values = [row[0] for row in result]
+
+    assert values == ["keep"]
+    assert db_path.exists()


### PR DESCRIPTION
## Summary
- configure the orchestrator service in docker-compose to default to the persisted SQLite database path
- document the default SQLite location and its persistence in the README
- add regression tests to verify the default URL and that existing SQLite databases are reused

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cddd0306ec8332a532162bc5f8258e