### PR TITLE
Remove README mention of backups volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,9 @@ backup-orchestrator/
    └─ app/            # código del orquestador (UI + scheduler + runner)
 ```
 
-### ¿Para qué usamos el volumen `backups`?
+### ¿Cómo se montan las carpetas locales?
 
-El servicio define un volumen Docker llamado `backups` que se monta dentro del
-contenedor en la ruta `/backups`. Ese espacio queda disponible para compartir
-archivos temporales entre el orquestador y las apps que exportan sus datos.
-
-Además se monta la carpeta indicada por la variable `LOCAL_DIRECTORIES_ROOT`
+El servicio monta la carpeta indicada por la variable `LOCAL_DIRECTORIES_ROOT`
 (por defecto `./datosPersistentes/local-directories`) en la ruta
 `/local-directories`. Allí es donde deben existir las carpetas locales que se
 exponen a través de los remotes de rclone. Configurá la variable


### PR DESCRIPTION
## Summary
- remove the README section that described the deprecated `backups` volume
- clarify how local directories are mounted for local remotes

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cddefb6eec83328a34020ff5717077