### PR TITLE
Update local remote storage to /backupsLocales

### DIFF
--- a/docs/ui_usage.md
+++ b/docs/ui_usage.md
@@ -5,7 +5,7 @@ funcionalidades ofrece cada sección.
 
 ## 1. Acceso y navegación
 1. Levantar el proyecto con Docker (`docker compose up -d`).
-2. Abrir `http://localhost:5550` (o el puerto configurado en `APP_PORT`).
+2. Abrir `http://localhost:5550` (o el puerto configurado en `PORT`).
 3. Ingresar con las credenciales definidas en `APP_ADMIN_USER` y `APP_ADMIN_PASS`.
 4. Una vez autenticado se muestra una barra superior con:
    - **Apps**: listado y alta de aplicaciones.
@@ -43,7 +43,7 @@ La interfaz permite crear nuevos remotes sin abandonar el navegador.
 - Ingresá a **Rclone → Remotes** para ver el listado actual y el formulario de alta.
 - Completá **Nombre** y elegí el **Tipo** de backend (`drive`, `onedrive`, `sftp` o `local`). El formulario mostrará los campos necesarios según la opción seleccionada:
   - Para `drive`, la opción predeterminada "Usar la cuenta provista" crea una carpeta dentro del remote global (`RCLONE_REMOTE`, habitualmente `gdrive`), la comparte con el correo indicado y genera un alias (`rclone config create <nombre> alias remote gdrive:<carpeta>`). Si preferís otra cuenta, cambiá al modo personalizado y pegá un token OAuth propio.
-  - Para `local`, seleccioná una carpeta habilitada previamente en `RCLONE_LOCAL_DIRECTORIES`.
+  - Para `local`, elegí la carpeta base `/backupsLocales` (montada desde `./datosPersistentes/backups/`).
 - Para `sftp`, ingresá host, puerto (opcional), usuario y contraseña. Probá la conexión para listar las carpetas disponibles en el servidor y elegí dónde crear la carpeta del remote.
 - Al guardar, la UI invoca internamente `rclone config create` y actualiza el listado de remotes disponibles.
 

--- a/orchestrator/app/__init__.py
+++ b/orchestrator/app/__init__.py
@@ -31,7 +31,7 @@ from orchestrator.scheduler import (
 )
 from orchestrator.services.client import _normalize_remote
 from orchestrator.local_dirs import (
-    parse_local_directory_config,
+    load_local_directory_entries,
     strip_enclosing_quotes,
 )
 
@@ -107,7 +107,7 @@ def create_app() -> Flask:
     app.secret_key = os.getenv("APP_SECRET_KEY", "devkey")
 
     def get_local_directories() -> list[dict[str, str]]:
-        return parse_local_directory_config(os.getenv("RCLONE_LOCAL_DIRECTORIES", ""))
+        return load_local_directory_entries()
 
     def _ensure_absolute_path(value: str | None) -> str | None:
         if value is None:

--- a/orchestrator/app/database.py
+++ b/orchestrator/app/database.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 
 
 def _default_database_url() -> str:
-    base_dir = "/datosPersistentes/db"
+    base_dir = "/sqlite/db"
     filename = "apps.db"
     path = os.path.join(base_dir, filename)
     return f"sqlite:////{path.lstrip('/')}"

--- a/orchestrator/local_dirs.py
+++ b/orchestrator/local_dirs.py
@@ -1,8 +1,12 @@
 """Helpers for working with configured local directories.
 
-This module centralizes the parsing of the ``RCLONE_LOCAL_DIRECTORIES``
-configuration value so it can be shared by the web application, scripts and
-support tooling such as docker-compose helpers.
+Historically the orchestrator relied on the ``RCLONE_LOCAL_DIRECTORIES``
+environment variable to list every bind mounted folder that could be exposed in
+the UI. The stack now ships with a fixed mount point (``/backupsLocales``)
+backed by the ``./datosPersistentes/backups`` directory on the host, so most
+deployments no longer need to provide that environment variable. This module
+keeps the parsing helpers for backwards compatibility while also exposing the
+new default directory.
 """
 from __future__ import annotations
 
@@ -11,12 +15,23 @@ import os
 import re
 from typing import Iterator
 
+DEFAULT_LOCAL_BACKUPS_ROOT = "/backupsLocales"
+"""Default directory inside the container to store local remotes."""
+
+BACKUPS_ROOT_ENV = "BACKUPER_LOCAL_BACKUPS_DIR"
+"""Environment variable that overrides the default local backups root."""
+
+LEGACY_DIRECTORIES_ENV = "RCLONE_LOCAL_DIRECTORIES"
+"""Legacy environment variable that accepted multiple bind mounts."""
+
 __all__ = [
     "strip_enclosing_quotes",
     "parse_local_directory_config",
     "iter_directory_paths",
     "compute_bind_mounts",
     "render_compose_bind_mounts",
+    "load_local_directory_entries",
+    "get_local_backups_root",
 ]
 
 
@@ -70,16 +85,68 @@ def iter_directory_paths(value: str) -> Iterator[str]:
         yield path
 
 
+def get_local_backups_root() -> str:
+    """Return the absolute path to the default local backups directory."""
+
+    raw_value = strip_enclosing_quotes(os.getenv(BACKUPS_ROOT_ENV, ""))
+    candidate = raw_value or DEFAULT_LOCAL_BACKUPS_ROOT
+    expanded = os.path.expanduser(candidate)
+    if not expanded:
+        expanded = candidate
+    return os.path.abspath(expanded)
+
+
+def _default_local_directory_entries() -> list[dict[str, str]]:
+    """Return entries for the default local backups directory."""
+
+    root_path = get_local_backups_root()
+    try:
+        os.makedirs(root_path, exist_ok=True)
+    except OSError:
+        return []
+    return [{"label": root_path, "path": root_path}]
+
+
+def load_local_directory_entries(value: str | None = None) -> list[dict[str, str]]:
+    """Return configured directories or fall back to the default root."""
+
+    raw_value = value if value is not None else os.getenv(LEGACY_DIRECTORIES_ENV, "")
+    entries = parse_local_directory_config(raw_value)
+    if not entries:
+        entries = _default_local_directory_entries()
+    normalized: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for entry in entries:
+        raw_path = entry.get("path") if isinstance(entry, dict) else None
+        path = strip_enclosing_quotes(str(raw_path or ""))
+        if not path:
+            continue
+        expanded = os.path.abspath(os.path.expanduser(path))
+        if not expanded:
+            continue
+        normalized_key = os.path.normcase(os.path.normpath(expanded))
+        if normalized_key in seen:
+            continue
+        seen.add(normalized_key)
+        raw_label = entry.get("label") if isinstance(entry, dict) else None
+        label = strip_enclosing_quotes(str(raw_label or "")) or expanded
+        normalized.append({"label": label, "path": expanded})
+    return normalized
+
+
 def compute_bind_mounts(value: str) -> list[tuple[str, str]]:
     """Return unique ``(source, target)`` tuples for docker bind mounts."""
 
     mounts: list[tuple[str, str]] = []
     seen: set[str] = set()
-    for path in iter_directory_paths(value):
-        expanded = os.path.expanduser(path)
-        if not expanded:
+    directories = load_local_directory_entries(value)
+    for entry in directories:
+        path = strip_enclosing_quotes(entry.get("path") if isinstance(entry, dict) else "")
+        if not path:
             continue
-        abs_path = os.path.abspath(expanded)
+        abs_path = os.path.abspath(os.path.expanduser(path))
+        if not abs_path:
+            continue
         normalized = os.path.normcase(os.path.normpath(abs_path))
         if normalized in seen:
             continue

--- a/orchestrator/scripts/render_local_mounts.py
+++ b/orchestrator/scripts/render_local_mounts.py
@@ -17,8 +17,9 @@ def _ensure_directories(paths: Iterable[str]) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Generate docker-compose volume entries for the directories listed "
-            "in RCLONE_LOCAL_DIRECTORIES."
+            "Generate docker-compose volume entries for configured local "
+            "directories. Falls back to the default /backupsLocales mount when "
+            "the legacy RCLONE_LOCAL_DIRECTORIES variable is not provided."
         )
     )
     parser.add_argument(
@@ -27,7 +28,8 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help=(
             "Directories string to parse. Defaults to the value from the "
-            "RCLONE_LOCAL_DIRECTORIES environment variable."
+            "RCLONE_LOCAL_DIRECTORIES environment variable, or the default "
+            "local backups directory if it is unset."
         ),
     )
     parser.add_argument(

--- a/tests/test_database_persistence.py
+++ b/tests/test_database_persistence.py
@@ -40,7 +40,7 @@ def test_default_database_url_points_to_persistent_volume(reload_database):
     parsed = make_url(url)
 
     assert parsed.get_backend_name() == "sqlite"
-    assert parsed.database == "/datosPersistentes/db/apps.db"
+    assert parsed.database == "/sqlite/db/apps.db"
 
 
 def test_existing_sqlite_database_is_reused(tmp_path, reload_database):

--- a/tests/test_rclone_api.py
+++ b/tests/test_rclone_api.py
@@ -423,7 +423,7 @@ def test_create_rclone_remote_local_success(monkeypatch, app, tmp_path):
             return DummyResult(stdout=json.dumps(payload))
         return DummyResult()
 
-    monkeypatch.setenv("RCLONE_LOCAL_DIRECTORIES", str(tmp_path))
+    monkeypatch.setenv("BACKUPER_LOCAL_BACKUPS_DIR", str(tmp_path))
     monkeypatch.setattr(subprocess, "run", fake_run)
     client = app.test_client()
     client.post("/login", data={"username": "admin", "password": "secret"})
@@ -511,7 +511,7 @@ def test_update_rclone_remote_local_success(monkeypatch, app, tmp_path):
             return DummyResult()
         return DummyResult()
 
-    monkeypatch.setenv("RCLONE_LOCAL_DIRECTORIES", str(tmp_path))
+    monkeypatch.setenv("BACKUPER_LOCAL_BACKUPS_DIR", str(tmp_path))
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     base_folder = tmp_path
@@ -632,7 +632,7 @@ def test_update_rclone_remote_failure_restores_backup(monkeypatch, app, tmp_path
             return DummyResult()
         return DummyResult()
 
-    monkeypatch.setenv("RCLONE_LOCAL_DIRECTORIES", str(tmp_path))
+    monkeypatch.setenv("BACKUPER_LOCAL_BACKUPS_DIR", str(tmp_path))
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     client = app.test_client()
@@ -836,7 +836,7 @@ def test_delete_rclone_remote_local_removes_folder(monkeypatch, app, tmp_path):
     remote_folder = base_folder / "foo"
     remote_folder.mkdir()
     config_entries["foo"]["remote"] = str(remote_folder)
-    monkeypatch.setenv("RCLONE_LOCAL_DIRECTORIES", str(base_folder))
+    monkeypatch.setenv("BACKUPER_LOCAL_BACKUPS_DIR", str(base_folder))
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     from orchestrator.app import SessionLocal
@@ -923,7 +923,7 @@ def test_restore_persisted_remotes_on_startup(monkeypatch, tmp_path):
     monkeypatch.setenv("APP_ADMIN_USER", "admin")
     monkeypatch.setenv("APP_ADMIN_PASS", "secret")
     monkeypatch.setenv("APP_SECRET_KEY", "key")
-    monkeypatch.setenv("RCLONE_LOCAL_DIRECTORIES", str(tmp_path))
+    monkeypatch.setenv("BACKUPER_LOCAL_BACKUPS_DIR", str(tmp_path))
     monkeypatch.setenv("RCLONE_CONFIG", str(config_file))
 
     commands: list[list[str]] = []


### PR DESCRIPTION
## Summary
- default local remote handling to the fixed /backupsLocales mount and expose a helper that falls back to it when no legacy configuration is provided
- change the default SQLite location to /sqlite/db/apps.db and refresh the documentation to describe the new volume layout
- adjust the tests and docker-compose smoke check to work with the new defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdee21f9508332bacc50e3939083c4